### PR TITLE
Initial RFC process' RFC

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,0 +1,81 @@
+# RFC Template
+
+- Feature Name: (fill me in with a unique ident, `new_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [Kuadrant/architecture#0000](https://github.com/Kuadrant/architecture/pull/0000)
+- Issue tracking: [Kuadrant/architecture#0000](https://github.com/Kuadrant/architecture/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was implemented and you were teaching it to Kuadrant user. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how a user should *think* about the feature, and how it would impact the way they already use Kuadrant. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing and new Kuadrant users.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- How error would be reported to the users.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- Does another project have a similar feature?
+- What can be learned from it? What's good? What's less optimal?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other tentatives - successful or not, provide readers of your RFC with a fuller picture.
+
+Note that while precedent set by other projects is some motivation, it does not on its own motivate an RFC.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would be and how it would affect the platform and project as a whole. Try to use this section as a tool to further consider all possible interactions with the project and its components in your proposal. Also consider how this all fits into the roadmap for the project and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the RFC you are writing but otherwise related.
+
+Note that having something written down in the future-possibilities section is not a reason to accept the current or a future RFC; such notes should be in the section on motivation or rationale in this or subsequent RFCs. The section merely provides additional information.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,59 @@ Note currently this repo is being updated and for know it is better to look at t
 - Cross cutting proposal that involves or impacts on more than one component within Kuadrant
 - Documents describing the overall architecture or a sub context (control plane / data plane) within the architecture 
 
+## Kuadrant RFCs
+
+The RFC (Request For Comments) process is aiming at providing a consistent and well understood way of adding new features or introducing breaking changes in the Kuadrant stack. It provides a mean for all stakeholders and community at large to provide feedback and be confident about the evolution of our solution.
+
+Many, if not most of the changes will not require to follow this process. Bug fixes, refactoring, performance improvements or documentation additions/improvements can be implemented using the tradition PR (Pull Request) model straight to the targeted repositories on Github. 
+
+Additions or any other changes that impact the end user experience will need to follow this process.
+
+### When is an RFC required?
+
+This process is meant for any changes that affect the user's experience in any way: addition of new APIs, changes to existing APIs - whether they are backwards compatible or not - and any other change to behaviour that affects the user of any components of Kuadrant.
+
+ - API additions;
+ - API changes;
+ - … any change in behaviour.
+
+#### When _no_ RFC is required?
+
+- bugfixes;
+- refactoring; 
+- performance improvements.
+
+
+### The RFC process
+
+The first step in adding a new feature to Kuadrant, or a starting a major change, is the having a RFC merged into the [repository](https://github.com/Kuadrant/architecture). One the file has been merged, the RFC is considered _active_ and ready to be worked on.
+
+1. Fork the RFC repo
+1. Use the template `0000-template.md` to copy and rename it into the `rfcs` directory. Change the `template` suffix to something descriptive. But this is still a proposal and as no assigned RFC number to it yet.
+1. Fill the template out. Try to be as thorough as possible. While some sections may not apply to your feature/change request, try to complete as much as possible, as this will be the basis for further discussions.
+1. Submit a pull request for the proposal. That's when the RFC is open for actual comments by other members of team and the broader community.
+1. The PR is to be handled just like a "code PR", wait on people's review and integrate the feedback provided. These RFCs can also be discussed during our weekly technical call meeting, yet the summary would need to be captured on the PR.
+1. How ever much the orignal proposal changes during this process, never force push or otherwise squash the history, or even rebase your branch. Try keeping the commit history as clean as possible on that PR, in order to keep a trace of how the RFC evolved.
+1. Once all point of views have been shared and input has been integrated in the PR, the author can push the RFC in the _final comment period_ (FCP) which lasts a week. This is the last chance for anyone to provide input. If during the FCP, consensus cannot be reached, it can be decided to extend that period by another week. Consensus is achieved by getting two approvals from the core team.
+1. As the PR is merged, it gets a number assigned, making the RFC _active_. 
+1. If on the other hand the consensus is to _not_ implement the feature as discussed, the PR is closed.
+
+### The RFC lifecycle
+
+- _Open_: A new RFC as been submitted as a proposal
+- _FCP_: Final comment period of one week for last comments
+- _Active_: RFC got a number assigned and is ready for implementation with the work tracked in an issue, which summarizes the state of the implementation work.
+
+#### Implementation
+
+The work is itself tracked in a "master" issue with all the individual, manageable implementation tasks tracked. 
+The state of that issue is initially "open" and ready for work, which doesn't mean it'd be worked on immediately or by the RFC's author. That work will be planned and integrated as part of the usual release cycle of the Kuadrant stack. 
+
+#### Amendments
+
+It isn't expected for an RFC to change, once it has become _active_. Minor changes are acceptable, but any major change to an active RFC should be treated as an independent RFC and go through the cycle described here.
+
+
 ## What doesn't belong here:
 
 - Specific component level documents that relate to the internal design of a component, these should reside within individual component repos


### PR DESCRIPTION
# Summary

This is an attempt at streamlining and formalizing the addition of features to Kuadrant and its components: `Authorino`, `Limitador` and possible more to come. It describes a process, Request For Comment (RFC). That process would be followed by contributors to Kuadrant in order to add features to the platform. The process aims at enabling the teams to deliver better defined software with a better experience for our end-users.

# Motivation

As I went through the process of redefining the syntax for `Condition`s in `Limitador`, I found it hard to seed people's mind with the problem's space as I perceived it. I started by asking questions on the issues itself that didn't get the traction I had hoped for until the PR was eventually opened.
This process should help the author to consider the proposed change in its entirety: the change, its pros & cons, its documentation and the error cases. Making it easier for reviewers to understand the impact of the change being considered.
Further more, this keeps a "written" record of "a decision log" of how a feature came to be. It would help the ones among us who tend to forget about things, but would be of incommensurate value for future contributors wanting to either understand a feature deeply or build upon certain features to enable a new one.

# Guide-level explanation

A contributor would start by following the template for a new _Request For Comment_ (RFC). Eventually opening a pull request with the proposed change explained. At which point it automatically becomes a point of discussion for the next upcoming _technical discussion_ weekly call. 
Anyone is free to add ideas, raise issues, point out possible missing bits in the proposal before the call on the PR itself. The outcome of the _technical discussion_ call is recorded on the PR as well, for future reference. 
Once the author feels the proposal is in a good shape and has addressed the comments provided by the team and community, they can label the RFC as _FCP_, entering the Final Comment Period_. From that point on, there is another week left for commenters to express any remaining concerns. After which, the RFC is merged and going into _active_ status, ready for implementation.

# Reference-level explanation

See the PR's content

# Drawbacks

The process proposed here adds overhead to addition of new features onto our stack. It will require more upfront specification work. It may require doing a few proof of concepts along the initial authoring, to enable the author to better understand the problem space.

# Rationale and alternatives

What we've done until now, `investigation`s have been less formal, but I'm unsure how much of their value got properly and entirely captured. By formalizing the process and having a clear outcome: a implementable piece of documentation, that address all aspects of the user's experience look like a better result. 

# Prior art

The entire idea isn't new. This very proposal is based on prior art by [`rust-lang`](https://github.com/rust-lang/rfcs) and [`pony-lang`](https://github.com/ponylang/rfcs). This process isn't perfect, but has been proven over and over again to work.

# Unresolved questions

- A week for the _FCP_ seems a lot and very little at the same time… should we revisit this?
- Having two core team member accepting an RFC is… acceptable? Should it be more? Less?
- ~Should this all go under `Kuadrant/rfcs`?~ `Kuadrant/architecture` it is…
- What does it mean for [`kcp-glbc`](https://github.com/Kuadrant/kcp-glbc) ?


# Future possibilities

I certainly see this process itself evolving overtime. I like to think that this process can itself be supporting its future changes…

