### PR TITLE
Fixing policy links in architecture overview doc

### DIFF
--- a/docs/design/architectural-overview-v1.md
+++ b/docs/design/architectural-overview-v1.md
@@ -3,8 +3,8 @@
 <!--- variables for repeated links --->
 [AuthPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/auth/
 [RateLimitPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/
-[TLSPolicy]: https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/reference/tlspolicy.md
-[DNSPolicy]: https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/reference/dnspolicy.md
+[TLSPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/tls/
+[DNSPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/dns/
 [KuadrantCRD]: https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/reference/kuadrant.md
 
 

--- a/docs/design/architectural-overview.md
+++ b/docs/design/architectural-overview.md
@@ -3,8 +3,8 @@
 <!--- variables for repeated links --->
 [AuthPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/auth/
 [RateLimitPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/
-[TLSPolicy]: https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/reference/tlspolicy.md
-[DNSPolicy]: https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/reference/dnspolicy.md
+[TLSPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/tls/
+[DNSPolicy]: https://docs.kuadrant.io/kuadrant-operator/doc/dns/
 
 ## Overview
 


### PR DESCRIPTION
**What**
Current links for both DNS and TLS policies in the architecture overview document are broken. Updating to point to current docs links