### PR TITLE
RFC: X.509 Client Certificate Authentication in the AuthPolicy

### DIFF
--- a/rfcs/0015-x509-client-cert-authpolicy.md
+++ b/rfcs/0015-x509-client-cert-authpolicy.md
@@ -642,7 +642,6 @@ Documentation must explicitly warn users:
 
 1. **API Design**:
    - Finalize `X509CertificateSource` struct design
-   - Review with maintainers
    - Update API documentation
 
 2. **Implementation**:
@@ -1143,7 +1142,6 @@ def test_x509_authentication_expired_cert(gateway_with_client_cert_validation,
 2. **API Versioning**:
    - [ ] Should the new `source` field be added to Authorino v1beta3 or require a new v1beta4?
    - [ ] Recommendation: Add to v1beta3 as optional field (backward compatible)
-   - [ ] Get maintainer approval
 
 3. **Certificate Chain Handling**:
    - [ ] How should Authorino handle certificate chains in XFCC?


### PR DESCRIPTION
RFC: X.509 Client Certificate Authentication in the Kuadrant AuthPolicy

Closes #140

----

The RFC doc was initially generated by Claude Code AI from the following prompt and then adjusted manually for correction:

```
In the rfcs directory, generate a new design doc for the feature described in this Github issue: https://github.com/Kuadrant/architecture/issues/140.

You don't have to follow the RFC template strictly. Rather, this is a doc for AI agents like yourself to consume and later help me with things such as: feature refinement, creating the corresponding issues in Github, open pull requests containing the actual code changes, tracking the progress of the implementation in the doc itself. I would like to see sections such as Goals, Non-goals, Changes to the architecture (if any), API changes, Changes to Kuadrant components (Authorino, Kuadrant Operator, wasm-shim, etc), Security considerations, Alternatives considered, Implementation plan, Testing strategy (unit tests, integration tests, e2e tests), Changes to Kuadrant testsuite, TODOs list. The sections don't have to be in this exact order, nor use these exact titles.

Kuadrant repos whose content you may want to check in the process to propose a solution for the issue:
- https://github.com/Kuadrant/architecture (this repo)
- https://github.com/Kuadrant/authorino
- https://github.com/Kuadrant/authorino-operator
- https://github.com/Kuadrant/kuadrant-operator
- https://github.com/Kuadrant/wasm-shim
- https://github.com/Kuadrant/testsuite.

Now here's my perspective of what the problem is and the desired solution.

**The problem:** Authorino's AuthConfig supports using X.509 client certificates as a method to authenticate requests. The feature was propagated to Kuadrant's AuthPolicy API, misleading users that this was a feature supported in Kuadrant whereas it isn't. It is not supported due to a limitation of the wasm-shim that prevents it from reading the client certificate in PEM format and therefore it cannot pass the certificate in the request to external authorisation.

**The solution:** The solution I have in mind will be somewhat inspired by the workaround described in the Github issue. I would like for the Authorino's AuthConfig CRD to be extended so users can specify `authentication.x509` indicating that the client certificates should be extracted from the `X-Forwarded-Client-Cert` (XFCC) header that is known to be added by the proxy, instead of the default `attributes.source.certificate` field of the `CheckRequest`. Maybe an option to customise this header could also be a good idea. The change to AuthConfig API needs to be reflected in the Authorino manifests hosted in the Authorino Operator repo and then propagated to the AuthPolicy in the Kuadrant Operator repo. Instead of the approach used in the workaround of creating an Istio EnvoyFilter resource, enabling client TLS validation in the proxy will be handled by the Gateway API implementation, via the Gateway's `spec.tls.frontend.default.validation option`. This approach was described in this comment of the same Github issue: https://github.com/Kuadrant/architecture/issues/140#issuecomment-3920630818. The feature was Experimental until Gateway API v1.4 but has just become Standard as of Gateway v1.5.
```