### PR TITLE
rfc: updates to the api design in rfc 0015

### DIFF
--- a/rfcs/0015-x509-client-cert-authpolicy.md
+++ b/rfcs/0015-x509-client-cert-authpolicy.md
@@ -77,7 +77,7 @@ spec:
         # If omitted, defaults to `source.certificate` (CheckRequest attributes)
         source:
           # Option 1: Extract from XFCC header (Envoy format)
-          xfcc: "x-forwarded-client-cert"
+          xfccHeader: "x-forwarded-client-cert"
           # Option 2: Extract from HTTP header (RFC 9440 format)
           # clientCertHeader: "client-cert"
           # Option 3: Extract using CEL expression
@@ -91,7 +91,7 @@ spec:
 ```
 
 **Behavior**:
-- When `source.xfcc` is specified, Authorino extracts the certificate from the named HTTP header using Envoy XFCC format
+- When `source.xfccHeader` is specified, Authorino extracts the certificate from the named HTTP header using Envoy XFCC format
 - When `source.clientCertHeader` is specified, Authorino extracts the certificate from the named HTTP header using RFC 9440 format
 - When `source.expression` is specified, Authorino evaluates the CEL expression to extract the certificate
 - When `source` is omitted, Authorino uses the current behavior of reading from `attributes.source.certificate` (backward compatibility)
@@ -219,7 +219,7 @@ For Tier 3, there are two approaches:
 ```yaml
 x509:
   source:
-    xfcc: "x-forwarded-client-cert"
+    xfccHeader: "x-forwarded-client-cert"
 ```
 
 **Gateway Configuration** (Istio example):
@@ -364,12 +364,12 @@ type X509AuthenticationSpec struct {
 }
 
 // X509CertificateSource defines the source from which to extract the client certificate
-// Only one of XFCC, ClientCertHeader, or Expression should be specified
+// Only one of XFCCHeader, ClientCertHeader, or Expression should be specified
 type X509CertificateSource struct {
-    // XFCC specifies the HTTP header name containing the client certificate in Envoy XFCC format
+    // XFCCHeader specifies the HTTP header name containing the client certificate in Envoy XFCC format
     // Typically "x-forwarded-client-cert" for certificates forwarded by Envoy-based proxies
     // +optional
-    XFCC string `json:"xfcc,omitempty"`
+    XFCCHeader string `json:"xfccHeader,omitempty"`
 
     // ClientCertHeader specifies the HTTP header name containing the client certificate in RFC 9440 format
     // For certificates forwarded according to RFC 9440 specification
@@ -385,10 +385,10 @@ type X509CertificateSource struct {
 
 **Default behavior**:
 - If `source` is not specified: backward compatible behavior (read from `attributes.source.certificate`)
-- If `source.xfcc` is specified: extract certificate from the named HTTP header using Envoy XFCC format
+- If `source.xfccHeader` is specified: extract certificate from the named HTTP header using Envoy XFCC format
 - If `source.clientCertHeader` is specified: extract certificate from the named HTTP header using RFC 9440 format
 - If `source.expression` is specified: evaluate the CEL expression to extract the certificate
-- If multiple fields are specified: `xfcc` takes precedence, followed by `clientCertHeader`, then `expression`
+- If multiple fields are specified: `xfccHeader` takes precedence, followed by `clientCertHeader`, then `expression`
 
 ## Kuadrant AuthPolicy CRD
 
@@ -410,7 +410,7 @@ spec:
         "x509-from-gateway":
           x509:
             source:
-              xfcc: "x-forwarded-client-cert"
+              xfccHeader: "x-forwarded-client-cert"
             selector:
               matchLabels:
                 app.kubernetes.io/name: trusted-client
@@ -428,8 +428,8 @@ spec:
    - Add `Source` field to `X509AuthenticationSpec`
 
 2. **X.509 Authenticator** (`pkg/evaluators/identity/x509.go`):
-   - Add logic to check which source type is configured (`xfcc`, `clientCertHeader`, or `expression`)
-   - If `xfcc` is configured, extract certificate from the HTTP request header using Envoy XFCC format
+   - Add logic to check which source type is configured (`xfccHeader`, `clientCertHeader`, or `expression`)
+   - If `xfccHeader` is configured, extract certificate from the HTTP request header using Envoy XFCC format
    - If `clientCertHeader` is configured, extract certificate from the HTTP request header using RFC 9440 format
    - If `expression` is configured, evaluate the CEL expression to extract the certificate
    - Parse the appropriate header format (URL-encoded PEM for XFCC, RFC 9440 format for clientCertHeader)
@@ -476,7 +476,7 @@ spec:
    - Update CRD manifests
 
 2. **AuthPolicy-to-AuthConfig Translation** (`internal/controller/authconfigs_reconciler.go` or similar):
-   - Propagate `authentication.<name>.x509.source` (including `xfcc`, `clientCertHeader`, and `expression` fields) from AuthPolicy to generated AuthConfig
+   - Propagate `authentication.<name>.x509.source` (including `xfccHeader`, `clientCertHeader`, and `expression` fields) from AuthPolicy to generated AuthConfig
    - No additional business logic required
 
 3. **Documentation**:
@@ -849,7 +849,7 @@ Documentation must explicitly warn users:
 
 ### Kuadrant Operator
 - **API Translation**:
-  - AuthPolicy with `x509.source.xfcc` → AuthConfig with same config
+  - AuthPolicy with `x509.source.xfccHeader` → AuthConfig with same config
   - AuthPolicy with `x509.source.clientCertHeader` → AuthConfig with same config
   - AuthPolicy with `x509.source.expression` → AuthConfig with same config
   - AuthPolicy without `source` → AuthConfig with default behavior
@@ -876,7 +876,7 @@ Documentation must explicitly warn users:
   - Gateway with `spec.tls.frontend.default.validation` configured
   - CA certificate ConfigMap for gateway validation
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
+  - AuthPolicy with `x509.source.xfccHeader: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Client with valid certificate → 200 OK
@@ -888,7 +888,7 @@ Documentation must explicitly warn users:
   - Gateway with EnvoyFilter configuring TLS client validation
   - CA certificate file mounted in gateway pod
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
+  - AuthPolicy with `x509.source.xfccHeader: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Same as Scenario 1
@@ -898,7 +898,7 @@ Documentation must explicitly warn users:
   - Gateway with `forwardClientCertDetails: ALWAYS_FORWARD_ONLY` annotation
   - No gateway-level TLS client validation configured
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
+  - AuthPolicy with `x509.source.xfccHeader: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Client with valid certificate in XFCC header → 200 OK (validated by Authorino only)
@@ -926,7 +926,7 @@ Documentation must explicitly warn users:
 - Test: Client certificate signed by intermediate CA (full chain in XFCC)
 
 **Test Scenario 5: Custom Header Names and Formats**
-- Setup 5a: AuthPolicy with `x509.source.xfcc: "x-custom-xfcc-header"`
+- Setup 5a: AuthPolicy with `x509.source.xfccHeader: "x-custom-xfcc-header"`
 - Setup 5b: AuthPolicy with `x509.source.clientCertHeader: "client-cert"`
 - Setup 5c: AuthPolicy with `x509.source.expression: request.headers["pem-cert"]`
 - Modify gateway to use custom headers (implementation-specific)
@@ -1144,7 +1144,7 @@ def x509_auth_policy(route, module_label):
                     "authentication": {
                         "x509-authn": {
                             "x509": {
-                                "source": {"xfcc": "x-forwarded-client-cert"},
+                                "source": {"xfccHeader": "x-forwarded-client-cert"},
                                 "selector": {
                                     "matchLabels": {"app": "trusted-client"}
                                 }

--- a/rfcs/0015-x509-client-cert-authpolicy.md
+++ b/rfcs/0015-x509-client-cert-authpolicy.md
@@ -74,11 +74,14 @@ spec:
     "x509-authn":
       x509:
         # New field: specify the source of the certificate
+        # If omitted, defaults to `source.certificate` (CheckRequest attributes)
         source:
-          # Option 1: Extract from HTTP header (default: X-Forwarded-Client-Cert)
-          header: "X-Forwarded-Client-Cert"
-          # Option 2: Extract from CheckRequest attributes (current behavior)
-          # attribute: "source.certificate"
+          # Option 1: Extract from XFCC header (Envoy format)
+          xfcc: "x-forwarded-client-cert"
+          # Option 2: Extract from HTTP header (RFC 9440 format)
+          # clientCertHeader: "client-cert"
+          # Option 3: Extract using CEL expression
+          # expression: request.headers["pem-encoded-client-cert"]
 
         # Existing x509 validation fields
         selector:
@@ -88,9 +91,12 @@ spec:
 ```
 
 **Behavior**:
-- When `source.header` is specified, Authorino extracts the certificate from the named HTTP request header
-- When `source.attribute` is specified (or neither is specified for backward compatibility), Authorino uses the current behavior of reading from `attributes.source.certificate`
+- When `source.xfcc` is specified, Authorino extracts the certificate from the named HTTP header using Envoy XFCC format
+- When `source.clientCertHeader` is specified, Authorino extracts the certificate from the named HTTP header using RFC 9440 format
+- When `source.expression` is specified, Authorino evaluates the CEL expression to extract the certificate
+- When `source` is omitted, Authorino uses the current behavior of reading from `attributes.source.certificate` (backward compatibility)
 - The XFCC header format follows the [Envoy specification](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert)
+- The clientCertHeader format follows [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440.html)
 - Certificate validation (leaf maps to a trusted CA) remains unchanged once the certificate is extracted
 
 ### Propagate API Changes Through the Stack
@@ -201,12 +207,22 @@ spec:
 
 **When to use**: Use this approach when Gateway API v1.5+ is not available but you need TLS client certificate validation.
 
-### Tier 3: User-Specified XFCC Forwarding (Exceptional Cases)
+### Tier 3: User-Specified Certificate Forwarding (Exceptional Cases)
 
-In exceptional scenarios where TLS client certificate validation **cannot** be configured at the gateway level (e.g., gateway is managed by another team, or validation must happen exclusively at L7), users can configure the proxy to **forward user-specified XFCC headers without validation**.
+In exceptional scenarios where TLS client certificate validation **cannot** be configured at the gateway level (e.g., gateway is managed by another team, or validation must happen exclusively at L7), users can configure their application to send client certificates via HTTP headers for L7-only validation.
 
-**Example with Istio Gateway annotation**:
+For Tier 3, there are two approaches:
 
+#### Option A: XFCC Header with Envoy Format (Requires Proxy Configuration)
+
+**AuthPolicy Configuration**:
+```yaml
+x509:
+  source:
+    xfcc: "x-forwarded-client-cert"
+```
+
+**Gateway Configuration** (Istio example):
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -219,8 +235,26 @@ spec:
 ```
 
 **Behavior**:
-- The proxy **forwards** the XFCC header from the incoming request without validating the certificate
-- Clients must provide their certificate in the XFCC header (typically as a PEM-encoded string)
+- The proxy **forwards** the X-Forwarded-Client-Cert header from the incoming request without validating the certificate
+- Clients must provide their certificate in the XFCC header using Envoy XFCC format
+- Requires proxy configuration to enable header forwarding
+- **No TLS-level certificate validation occurs** at the gateway
+
+#### Option B: RFC 9440 Client-Cert Header
+
+**AuthPolicy Configuration**:
+```yaml
+x509:
+  source:
+    clientCertHeader: "client-cert"
+```
+
+**Gateway Configuration**: No special configuration needed (most proxies treat Client-Cert as a normal header)
+
+**Behavior**:
+- Clients provide their certificate in the Client-Cert header using RFC 9440 format (DER-encoded, URL-encoded, colon-delimited)
+- The proxy treats Client-Cert as any normal HTTP header and forwards it
+- **No special proxy configuration required** (unlike Option A)
 - **No TLS-level certificate validation occurs** at the gateway
 
 **Security Implications**:
@@ -229,11 +263,21 @@ spec:
 - **Client key possession not verified**: Since the certificate is passed as a header (not via TLS handshake), there's no cryptographic proof that the client possesses the private key corresponding to the certificate.
 - **Spoofing risk**: If the XFCC header reaches the proxy from an untrusted source (e.g., through another proxy in the chain), it could be spoofed.
 
-**When to use**: Use this approach **only** in exceptional cases where:
+**When to use Tier 3**: Use this approach **only** in exceptional cases where:
 - Gateway-level TLS validation is not possible or not desired
 - You accept the security trade-offs of L7-only certificate validation
-- You trust the source of the XFCC header (e.g., it comes from a trusted upstream proxy)
+- You trust the source of the certificate header (e.g., it comes from a trusted upstream proxy or controlled client)
 - You understand that certificate private key possession is not cryptographically verified
+
+**Choosing between Option A and Option B**:
+- **Use Option A (XFCC)** when:
+  - Your clients are already using Envoy XFCC format
+  - You have existing infrastructure using X-Forwarded-Client-Cert
+  - Your proxy setup already has `forwardClientCertDetails` configured
+- **Use Option B (RFC 9440)** when:
+  - You want simpler configuration (no proxy settings needed)
+  - Your clients can provide certificates in RFC 9440 format
+  - You prefer standard-based approaches
 
 **Not recommended** for production security-critical applications.
 
@@ -320,24 +364,31 @@ type X509AuthenticationSpec struct {
 }
 
 // X509CertificateSource defines the source from which to extract the client certificate
-// Only one of Header or Attribute should be specified
+// Only one of XFCC, ClientCertHeader, or Expression should be specified
 type X509CertificateSource struct {
-    // Header specifies the HTTP header name containing the client certificate in PEM format
-    // Typically "X-Forwarded-Client-Cert" for certificates forwarded by the proxy
+    // XFCC specifies the HTTP header name containing the client certificate in Envoy XFCC format
+    // Typically "x-forwarded-client-cert" for certificates forwarded by Envoy-based proxies
     // +optional
-    Header string `json:"header,omitempty"`
+    XFCC string `json:"xfcc,omitempty"`
 
-    // Attribute specifies the CheckRequest attribute path containing the certificate
-    // Default behavior if neither Header nor Attribute is specified
+    // ClientCertHeader specifies the HTTP header name containing the client certificate in RFC 9440 format
+    // For certificates forwarded according to RFC 9440 specification
     // +optional
-    Attribute string `json:"attribute,omitempty"`
+    ClientCertHeader string `json:"clientCertHeader,omitempty"`
+
+    // Expression specifies a CEL expression to extract the client certificate
+    // Can be used for custom certificate extraction logic
+    // +optional
+    Expression string `json:"expression,omitempty"`
 }
 ```
 
 **Default behavior**:
 - If `source` is not specified: backward compatible behavior (read from `attributes.source.certificate`)
-- If `source.header` is specified: extract certificate from the named HTTP header
-- If both `header` and `attribute` are specified: `header` takes precedence
+- If `source.xfcc` is specified: extract certificate from the named HTTP header using Envoy XFCC format
+- If `source.clientCertHeader` is specified: extract certificate from the named HTTP header using RFC 9440 format
+- If `source.expression` is specified: evaluate the CEL expression to extract the certificate
+- If multiple fields are specified: `xfcc` takes precedence, followed by `clientCertHeader`, then `expression`
 
 ## Kuadrant AuthPolicy CRD
 
@@ -359,7 +410,7 @@ spec:
         "x509-from-gateway":
           x509:
             source:
-              header: "X-Forwarded-Client-Cert"
+              xfcc: "x-forwarded-client-cert"
             selector:
               matchLabels:
                 app.kubernetes.io/name: trusted-client
@@ -377,20 +428,26 @@ spec:
    - Add `Source` field to `X509AuthenticationSpec`
 
 2. **X.509 Authenticator** (`pkg/evaluators/identity/x509.go`):
-   - Add logic to check if `source.header` is configured
-   - If configured, extract certificate from the HTTP request header instead of CheckRequest attributes
-   - Parse XFCC header format (URL-encoded PEM, potentially with additional metadata)
+   - Add logic to check which source type is configured (`xfcc`, `clientCertHeader`, or `expression`)
+   - If `xfcc` is configured, extract certificate from the HTTP request header using Envoy XFCC format
+   - If `clientCertHeader` is configured, extract certificate from the HTTP request header using RFC 9440 format
+   - If `expression` is configured, evaluate the CEL expression to extract the certificate
+   - Parse the appropriate header format (URL-encoded PEM for XFCC, RFC 9440 format for clientCertHeader)
    - Maintain existing certificate validation logic
 
 3. **Tests**:
-   - Unit tests for XFCC header parsing
-   - Integration tests with mock XFCC headers
+   - Unit tests for XFCC header parsing (Envoy format)
+   - Unit tests for clientCertHeader parsing (RFC 9440 format)
+   - Unit tests for CEL expression evaluation
+   - Integration tests with mock headers
    - Backward compatibility tests (ensure existing configs still work)
 
 **Estimated Complexity**: Low-Medium
 - XFCC header parsing is straightforward (URL-encoded PEM)
+- RFC 9440 format parsing is well-specified
+- CEL expression evaluation leverages existing CEL infrastructure
 - Existing certificate validation logic is reused
-- Main risk: XFCC format variations across different proxies
+- Main risk: Format variations across different proxies and implementations
 
 ## Authorino Operator
 
@@ -419,13 +476,14 @@ spec:
    - Update CRD manifests
 
 2. **AuthPolicy-to-AuthConfig Translation** (`internal/controller/authconfigs_reconciler.go` or similar):
-   - Propagate `authentication.<name>.x509.source` from AuthPolicy to generated AuthConfig
+   - Propagate `authentication.<name>.x509.source` (including `xfcc`, `clientCertHeader`, and `expression` fields) from AuthPolicy to generated AuthConfig
    - No additional business logic required
 
 3. **Documentation**:
-   - Update AuthPolicy examples to show X.509 authentication with XFCC header
+   - Update AuthPolicy examples to show X.509 authentication with different source options (XFCC, clientCertHeader, expression)
    - Document the requirement for Gateway `spec.tls.frontend.default.validation` configuration
-   - Provide complete working example combining Gateway config + AuthPolicy
+   - Document the differences between XFCC (Envoy format) and clientCertHeader (RFC 9440 format)
+   - Provide complete working examples combining Gateway config + AuthPolicy for each source type
 
 **Estimated Complexity**: Low-Medium
 - Straightforward API propagation
@@ -646,18 +704,28 @@ Documentation must explicitly warn users:
 
 2. **Implementation**:
    - Add types to `api/v1beta3/auth_config_types.go`
-   - Implement XFCC header parsing in `pkg/evaluators/identity/x509.go`
-   - Handle URL-encoded PEM format
+   - Implement certificate extraction in `pkg/evaluators/identity/x509.go`:
+     - XFCC header parsing (Envoy format)
+     - ClientCertHeader parsing (RFC 9440 format)
+     - CEL expression evaluation
+   - Handle URL-encoded PEM format (for XFCC)
    - Parse Envoy XFCC format (may include multiple fields like `By`, `Hash`, `Cert`, `Chain`, `Subject`, `URI`, `DNS`)
+   - Parse RFC 9440 format
 
 3. **Testing**:
-   - Unit tests for XFCC parsing
+   - Unit tests for XFCC parsing (Envoy format)
+   - Unit tests for clientCertHeader parsing (RFC 9440 format)
+   - Unit tests for CEL expression evaluation
    - Unit tests for backward compatibility
    - Integration tests with mock headers
 
 4. **Documentation**:
    - Update AuthConfig documentation
-   - Add examples of XFCC-based x509 authentication
+   - Add examples of x509 authentication with different source types:
+     - XFCC (Envoy format)
+     - ClientCertHeader (RFC 9440 format)
+     - CEL expression
+   - Document the differences between formats and when to use each
 
 **Deliverables**:
 - PR to Authorino repository
@@ -703,9 +771,11 @@ Documentation must explicitly warn users:
    - For each tier, show:
      - Complete Gateway/proxy configuration
      - CA certificate ConfigMap (for Tier 1/2)
-     - AuthPolicy with `x509.source.header`
+     - AuthPolicy with appropriate `x509.source` configuration (xfcc, clientCertHeader, or expression)
      - HTTPRoute binding
    - Document security considerations and trade-offs of each tier
+   - Document the differences between XFCC (Envoy format), clientCertHeader (RFC 9440 format), and expression
+   - Document when to use each source type
    - Document Authorino's multi-CA trust capabilities via label selectors
 
 **Deliverables**:
@@ -759,16 +829,17 @@ Documentation must explicitly warn users:
 ## Unit Tests
 
 ### Authorino
-- **XFCC Header Parsing**:
-  - Valid PEM certificates in XFCC format
-  - URL-encoded PEM parsing
+- **Certificate Header Parsing**:
+  - Valid PEM certificates in XFCC format (Envoy)
+  - Valid PEM certificates in RFC 9440 format
+  - URL-encoded PEM parsing (XFCC)
   - Multiple certificates in XFCC (chain)
-  - Malformed XFCC headers
-  - Empty/missing XFCC header when configured
+  - Malformed headers
+  - Empty/missing headers when configured
+  - CEL expression evaluation for custom extraction
 
 - **Backward Compatibility**:
-  - AuthConfigs without `source` field (should use default behavior)
-  - AuthConfigs with `source.attribute` field
+  - AuthConfigs without `source` field (should use default behavior reading from `attributes.source.certificate`)
 
 - **Certificate Validation**:
   - Valid certificates matching label selectors
@@ -778,7 +849,9 @@ Documentation must explicitly warn users:
 
 ### Kuadrant Operator
 - **API Translation**:
-  - AuthPolicy with `x509.source.header` → AuthConfig with same config
+  - AuthPolicy with `x509.source.xfcc` → AuthConfig with same config
+  - AuthPolicy with `x509.source.clientCertHeader` → AuthConfig with same config
+  - AuthPolicy with `x509.source.expression` → AuthConfig with same config
   - AuthPolicy without `source` → AuthConfig with default behavior
   - Complex scenarios with multiple authentication methods
 
@@ -803,7 +876,7 @@ Documentation must explicitly warn users:
   - Gateway with `spec.tls.frontend.default.validation` configured
   - CA certificate ConfigMap for gateway validation
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.header: "X-Forwarded-Client-Cert"`
+  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Client with valid certificate → 200 OK
@@ -815,7 +888,7 @@ Documentation must explicitly warn users:
   - Gateway with EnvoyFilter configuring TLS client validation
   - CA certificate file mounted in gateway pod
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.header: "X-Forwarded-Client-Cert"`
+  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Same as Scenario 1
@@ -825,7 +898,7 @@ Documentation must explicitly warn users:
   - Gateway with `forwardClientCertDetails: ALWAYS_FORWARD_ONLY` annotation
   - No gateway-level TLS client validation configured
   - CA certificate Secret(s) with labels for Authorino validation
-  - AuthPolicy with `x509.source.header: "X-Forwarded-Client-Cert"`
+  - AuthPolicy with `x509.source.xfcc: "x-forwarded-client-cert"`
   - HTTPRoute bound to AuthPolicy
 - Test:
   - Client with valid certificate in XFCC header → 200 OK (validated by Authorino only)
@@ -852,10 +925,12 @@ Documentation must explicitly warn users:
 - Setup: Intermediate CA certificates in XFCC
 - Test: Client certificate signed by intermediate CA (full chain in XFCC)
 
-**Test Scenario 5: Custom Header Name**
-- Setup: AuthPolicy with `x509.source.header: "X-Custom-Client-Cert"`
-- Modify gateway to use custom header (implementation-specific)
-- Test: Verification with custom header
+**Test Scenario 5: Custom Header Names and Formats**
+- Setup 5a: AuthPolicy with `x509.source.xfcc: "x-custom-xfcc-header"`
+- Setup 5b: AuthPolicy with `x509.source.clientCertHeader: "client-cert"`
+- Setup 5c: AuthPolicy with `x509.source.expression: request.headers["pem-cert"]`
+- Modify gateway to use custom headers (implementation-specific)
+- Test: Verification with each source type and format
 
 **Test Scenario 6: Backward Compatibility**
 - Setup: AuthPolicy without `source` field (legacy behavior)
@@ -1069,7 +1144,7 @@ def x509_auth_policy(route, module_label):
                     "authentication": {
                         "x509-authn": {
                             "x509": {
-                                "source": {"header": "X-Forwarded-Client-Cert"},
+                                "source": {"xfcc": "x-forwarded-client-cert"},
                                 "selector": {
                                     "matchLabels": {"app": "trusted-client"}
                                 }
@@ -1170,10 +1245,10 @@ def test_x509_authentication_expired_cert(gateway_with_client_cert_validation,
 
 6. **Proxy Configuration Guidance**:
    - [x] Should documentation include decision tree for choosing between Tier 1/2/3?
-   - [x] Should there be a warning/validation in AuthPolicy when using `x509.source.header` without proper gateway configuration?
+   - [x] Should there be a warning/validation in AuthPolicy when using `x509.source` without proper gateway configuration?
    - [x] How can users verify their gateway is properly configured for XFCC?
 
-   _Decision:_ Documentation will include a decision tree for choosing the appropriate proxy configuration tier based on user requirements and constraints. No warnings nor validation will be added to the AuthPolicy when using `x509.source.header` without proper gateway configuration. No specific tools will be provided for users to verify their configuration.
+   _Decision:_ Documentation will include a decision tree for choosing the appropriate proxy configuration tier based on user requirements and constraints. No warnings nor validation will be added to the AuthPolicy when using `x509.source` without proper gateway configuration. No specific tools will be provided for users to verify their configuration.
 
 7. **Automatic Gateway Configuration** (Future):
    - [ ] Should Kuadrant offer opt-in automatic injection of `spec.tls.frontend.default.validation` in a future version?
@@ -1263,7 +1338,7 @@ def test_x509_authentication_expired_cert(gateway_with_client_cert_validation,
   - Support both Tier 1 (Gateway API `spec.tls.frontend.default.validation`) and Tier 2 (EnvoyFilter) injection
   - Require explicit user opt-in to avoid unexpected mutations
   - Address ownership and conflict resolution with user-managed configurations
-- [ ] **Configuration Validation**: Add validation/warnings to AuthPolicy when `x509.source.header` is configured but gateway appears to lack proper TLS validation
+- [ ] **Configuration Validation**: Add validation/warnings to AuthPolicy when `x509.source` is configured but gateway appears to lack proper TLS validation
 - [ ] **Certificate Revocation**: Add support for CRL or OCSP-based certificate revocation checking in Authorino
 - [ ] **Dynamic CA Updates**: Hot-reload CA certificates without gateway restarts
 - [ ] **Certificate Metrics**: Expose Prometheus metrics for certificate validation (success/failure rates, expiration warnings, which tier was used)


### PR DESCRIPTION
Before:

```yaml
x509:
  source:
    header: "x-forwarded-client-cert" # envoy xfcc format
    -- OR --
    attribute: source.certificate # well-known attribute that resolves to pem-encoded → url-encoded cert
```

After:

```yaml
x509:
  source:
    xfcc: "x-forwarded-client-cert" # envoy xfcc format
    -- OR --
    clientCertHeader: "client-cert" # rfc 9440 format (der-encoded → url-encoded, colon-delimited)
    -- OR --
    expression: request.headers["pem-cert"] # CEL expression that resolves to pem-encoded → url-encoded cert
```

Rationale:
- **Using CEL instead of plain simple WKA:** CEL provides more options to the user, we have all the machinery already, and it's consistent with other features in the API (e.g. `authentication.plain`)
- **Support to RFC 9440:** despite not being widely adopted yet, provides a simpler way for users who need to fallback to Tier 3 compared to encoding the cert info in Envoy's proprietary XFCC format; it's also a new HTTP standard in the making dated from 2023.