### PR TITLE
docs(rfc-0017): Add hostname conflict design decision

### DIFF
--- a/rfcs/0017-grpcroute-support.md
+++ b/rfcs/0017-grpcroute-support.md
@@ -315,6 +315,31 @@ For gRPC requests, `request.method` will always be `POST` because that is the un
 
 **gRPC-specific well-known attributes:** The attributes `grpc.service` and `grpc.method` will be implemented as separate well-known attributes without breaking existing behavior or requiring changes to `request.method` semantics. This approach preserves protocol-accurate WKAs while providing gRPC-specific attributes for policy authors.
 
+#### Hostname Conflict Resolution Between Route Types
+
+**Decision:** HTTPRoute and GRPCRoute resources with overlapping hostnames cannot be attached to the same Gateway Listener. Gateway API implementations must reject subsequent routes during reconciliation by setting their `Accepted` condition to `False` in the route's status.
+
+**Behaviour per Gateway API specification:**
+- When routes of different types (HTTPRoute and GRPCRoute) are attached to the same Listener with matching or overlapping hostnames, the Gateway implementation enforces hostname uniqueness
+- The first route successfully attached (based on controller reconciliation order) is accepted
+- Subsequent conflicting routes receive `Accepted=False` status with a reason explaining the conflict
+- This prevents ambiguous routing where the same hostname could resolve to both HTTP and gRPC backends
+
+**Recommended practice:**
+- Use **separate hostnames** for HTTP and gRPC traffic (e.g., `api.example.com` for HTTPRoute, `grpc.example.com` for GRPCRoute)
+- This approach provides clear routing semantics and avoids rejection scenarios
+
+**Workaround for shared hostname:**
+- If the same hostname must serve both HTTP and gRPC traffic, use HTTPRoute for both types of traffic
+- HTTPRoute can match gRPC requests using path patterns (`/Service/Method`) and the `content-type: application/grpc` header
+- This loses the UX benefits of GRPCRoute's native service/method matching but allows hostname sharing
+
+**Kuadrant policy implications:**
+- Policies attached to **rejected routes** (those with `Accepted=False`) will not be enforced
+- The topology graph will include rejected routes, but their policy attachments are inactive
+- Users should monitor route status conditions to identify conflicts
+- Consider adding validation or warnings in the console plugin when detecting hostname overlaps between route types
+
 #### GRPCRouteMatch Predicate Patterns
 
 GRPCRouteMatch translates to CEL predicates using `request.url_path`:
@@ -589,6 +614,8 @@ when:
 - [GRPCRouteMatch spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch)
 - [GRPCMethodMatch spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCMethodMatch)
 - [Policy Attachment (GEP-713)](https://gateway-api.sigs.k8s.io/geps/gep-713/)
+- [GEP-1016: GRPCRoute Enhancement](https://gateway-api.sigs.k8s.io/geps/gep-1016/) — hostname conflict resolution between route types
+- [Gateway API Hostname Concepts](https://gateway-api.sigs.k8s.io/concepts/api-overview/#hostname-matching) — hostname matching and uniqueness requirements
 
 ### gRPC
 - [gRPC over HTTP/2 protocol spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)


### PR DESCRIPTION
## Summary

Adds a design decision section to RFC 0017 documenting Gateway API behaviour when HTTPRoute and GRPCRoute resources have overlapping hostnames on the same Gateway Listener.

## Changes

- Documents hostname uniqueness enforcement between route types
- Explains rejection mechanism (Accepted=False on second route attached)
- Provides recommended practices (use separate hostnames)
- Describes workaround options (HTTPRoute for both types)
- Outlines Kuadrant policy implications (rejected routes don't enforce policies)
- Adds GEP-1016 and Gateway API hostname concepts references

## Context

During GRPCRoute implementation, we identified that Gateway API has specific requirements for hostname conflicts between different route types. This wasn't previously documented in the RFC and could cause confusion during deployment.

Related to #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on hostname conflict resolution between HTTP and gRPC routes when attached to the same Gateway Listener
  * Documented expected behaviour for rejected routes and recommended practices for hostname configuration
  * Updated references to related Gateway API specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->