### PR TITLE
docs(rfc-0017): mark GRPCRoute support as Implemented

### DIFF
--- a/rfcs/0017-grpcroute-support.md
+++ b/rfcs/0017-grpcroute-support.md
@@ -1,7 +1,7 @@
 # Feature: GRPCRoute Support for Kuadrant Policies
 
 - Feature Name: `grpcroute-support`
-- Status: **Implementable**
+- Status: **Implemented**
 - Start Date: 2026-03-13
 - Issue tracking: [Kuadrant/architecture#156](https://github.com/Kuadrant/architecture/issues/156)
 
@@ -494,20 +494,6 @@ The `kuadrant/testsuite` repository provides the broader E2E test coverage follo
 
 ## Execution
 
-### Todo
-
-- [ ] **Task 9: testsuite - GRPCRoute E2E Test Coverage** (depends on Tasks 2, 7, optionally 10)
-  Add GRPCRoute support to the testsuite framework and E2E tests mirroring existing HTTPRoute test patterns. Test coverage for gRPC well-known attributes is optional but recommended.
-
-- [ ] **Task 10: wasm-shim & RFC 0002 - gRPC Well-Known Attributes** (no blockers - can be developed in parallel)
-  Implement `request.grpc` as a map containing `service` and `method` fields in the WASM shim for improved UX in policy conditions and rate limit counters. For gRPC requests (detected via `content-type: application/grpc` header AND successfully parsing `request.url_path` as `/Service/Method`), inject the `grpc` key into the `request` CEL variable as a map with `service` and `method` string fields. For non-gRPC requests or malformed gRPC paths, the `grpc` key must be absent from the `request` map (not defined), allowing presence checks via standard CEL `has(request.grpc)` macro. Update RFC 0002 specification with gRPC well-known attributes documentation.
-
-- [ ] **Task 11: authorino - gRPC Well-Known Attributes** (no blockers - can be developed in parallel)
-  Extract gRPC service and method components from requests and add to authorization JSON for use in OPA policies, CEL authorization rules, and other evaluators. For gRPC requests (detected via `content-type: application/grpc` header AND successfully parsing path as `/Service/Method`), include a `grpc` object in `input.request` with `service` and `method` fields. For non-gRPC requests or malformed gRPC paths, the `grpc` field must be absent (not present in the JSON) to align with OPA's undefined value semantics when checking field existence (e.g., `input.request.grpc.service` returns undefined for HTTP requests, allowing Rego policies to distinguish between HTTP and gRPC). Note: OPA/Rego does not have a `has()` built-in function; field presence is checked via undefined value semantics or using `object.get(input.request, "grpc", {})` with defaults.
-
-- [ ] **Task 12: kuadrant-console-plugin - GRPCRoute UI Support** (depends on Task 7)
-  Add GRPCRoute support to the OpenShift Console plugin: update resource registry, add GRPCRoute to topology visualization with icon and context menu, add "Policies" tab to GRPCRoute detail pages, create GRPCRoutePoliciesPage component, update RESOURCE_POLICY_MAP to show which policies can target GRPCRoute (excluding OIDCPolicy and TokenRateLimitPolicy).
-
 ### Completed
 
 - [x] **Task 1: policy-machinery - GRPCRoute Controller Wiring** — [Kuadrant/policy-machinery#65](https://github.com/Kuadrant/policy-machinery/issues/65)
@@ -533,6 +519,18 @@ The `kuadrant/testsuite` repository provides the broader E2E test coverage follo
 
 - [x] **Task 8: kuadrant-operator - Examples & Documentation** — [Kuadrant/kuadrant-operator#1827](https://github.com/Kuadrant/kuadrant-operator/issues/1827)
   Create example manifests and user guide documentation for gRPC with all supported policies, including grpcurl verification commands. Examples should demonstrate both `request.url_path` patterns and gRPC well-known attributes (if Task 10 is complete).
+
+- [x] **Task 9: testsuite - GRPCRoute E2E Test Coverage** — [Kuadrant/testsuite#886](https://github.com/Kuadrant/testsuite/issues/886)
+  Add GRPCRoute support to the testsuite framework and E2E tests mirroring existing HTTPRoute test patterns. Includes GRPCRoute class, gRPC backend, gRPC client library, test parametrization framework, parametrized smoke tests and extension policy tests, GRPCRoute-specific tests, and UI tests.
+
+- [x] **Task 10: wasm-shim & RFC 0002 - gRPC Well-Known Attributes** — [Kuadrant/wasm-shim#317](https://github.com/Kuadrant/wasm-shim/issues/317)
+  Implement `request.grpc` as a map containing `service` and `method` fields in the WASM shim for improved UX in policy conditions and rate limit counters. For gRPC requests (detected via `content-type: application/grpc` header AND successfully parsing `request.url_path` as `/Service/Method`), inject the `grpc` key into the `request` CEL variable as a map with `service` and `method` string fields. For non-gRPC requests or malformed gRPC paths, the `grpc` key is absent from the `request` map (not defined), allowing presence checks via standard CEL `has(request.grpc)` macro. RFC 0002 updated with gRPC well-known attributes documentation.
+
+- [x] **Task 11: authorino - gRPC Well-Known Attributes** — [Kuadrant/authorino#584](https://github.com/Kuadrant/authorino/issues/584)
+  Extract gRPC service and method components from requests and add to authorization JSON for use in OPA policies, CEL authorization rules, and other evaluators. For gRPC requests (detected via `content-type: application/grpc` header AND successfully parsing path as `/Service/Method`), include a `grpc` object in `input.request` with `service` and `method` fields. For non-gRPC requests or malformed gRPC paths, the `grpc` field is absent (not present in the JSON) to align with OPA's undefined value semantics when checking field existence.
+
+- [x] **Task 12: kuadrant-console-plugin - GRPCRoute UI Support** — [Kuadrant/kuadrant-console-plugin#367](https://github.com/Kuadrant/kuadrant-console-plugin/issues/367)
+  Add GRPCRoute support to the OpenShift Console plugin: update resource registry, add GRPCRoute to topology visualization with icon and context menu, add "Policies" tab to GRPCRoute detail pages, create GRPCRoutePoliciesPage component, update RESOURCE_POLICY_MAP to show which policies can target GRPCRoute (excluding OIDCPolicy and TokenRateLimitPolicy), add GRPCRoutes panel to overview page.
 
 ---
 

--- a/rfcs/0017-grpcroute-support.md
+++ b/rfcs/0017-grpcroute-support.md
@@ -638,6 +638,62 @@ when:
 
 **For route-level policies:** When a policy targets a specific GRPCRoute (not a Gateway), the `has(request.grpc)` check is technically optional since only gRPC traffic flows through GRPCRoute resources. However, including the check is recommended everywhere for defensive coding and clarity, as it makes policy intent explicit and prevents errors if policies are later reused.
 
+### "How do gRPC clients handle HTTP errors from policies?"
+
+**Envoy automatically translates HTTP status codes to gRPC status codes** for gRPC requests. All Kuadrant traffic flows through Envoy, which detects gRPC requests (via `content-type: application/grpc*`) and applies the [official gRPC HTTP-to-gRPC status mapping](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md) when sending responses.
+
+When the WASM shim returns HTTP status codes (401, 403, 429) to Envoy for policy rejections, Envoy translates these to appropriate `grpc-status` trailer values before forwarding to the client.
+
+**Key mappings:**
+
+| HTTP Status | gRPC Status Code | Policy Example |
+|-------------|------------------|----------------|
+| 401 Unauthorized | `UNAUTHENTICATED` (16) | AuthPolicy authentication failure |
+| 403 Forbidden | `PERMISSION_DENIED` (7) | AuthPolicy authorization denial |
+| 429 Too Many Requests | `UNAVAILABLE` (14) | RateLimitPolicy rate limit exceeded |
+
+**Note:** While `RESOURCE_EXHAUSTED` (8) would be semantically more appropriate for rate limiting, the standard HTTP-to-gRPC mapping uses `UNAVAILABLE` for HTTP 429.
+
+**AuthPolicy rejection example:**
+
+When Authorino rejects a request due to missing or invalid credentials:
+
+```
+# WASM shim returns HTTP 401 → Envoy translates to gRPC status
+HTTP/2 200 OK
+grpc-status: 16
+grpc-message: 
+
+# gRPC client receives
+ERROR:
+  Code: Unauthenticated
+  Message: 
+```
+
+**Note:** Currently the auth denial message is empty because Authorino returns an empty response body. This could be improved by having the WASM shim provide default messages for common auth failure scenarios.
+
+**RateLimitPolicy rejection example:**
+
+When Limitador rate limits a request:
+
+```
+# WASM shim returns HTTP 429 → Envoy translates to gRPC status
+HTTP/2 200 OK
+grpc-status: 14
+grpc-message: Too Many Requests
+
+# gRPC client receives
+ERROR:
+  Code: Unavailable
+  Message: Too Many Requests
+```
+
+**Important notes:**
+- Translation happens in Envoy, which detects gRPC requests and sets the `grpc-status` trailer based on the HTTP status code returned by the WASM shim
+- If Envoy weren't intercepting the requests, gRPC client libraries would perform the same translation using the standard mapping when receiving raw HTTP status codes
+- gRPC always uses HTTP/2 200 as the transport status; the actual RPC status is in the `grpc-status` trailer
+- Standard HTTP error codes from Kuadrant policies work correctly for gRPC traffic without special handling
+
 ---
 
 ## References
@@ -651,8 +707,10 @@ when:
 - [GEP-1016: GRPCRoute Enhancement](https://gateway-api.sigs.k8s.io/geps/gep-1016/) — hostname conflict resolution between route types
 - [Gateway API Hostname Concepts](https://gateway-api.sigs.k8s.io/concepts/api-overview/#hostname-matching) — hostname matching and uniqueness requirements
 
-### gRPC
+### gRPC & Envoy
 - [gRPC over HTTP/2 protocol spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)
+- [gRPC HTTP status to gRPC status mapping](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md) — official mapping used by Envoy and gRPC clients
+- [Envoy gRPC architecture overview](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_protocols/grpc) — how Envoy handles gRPC protocol translation
 
 ### Kuadrant
 - [Well-Known Attributes (RFC 0002)](https://github.com/Kuadrant/architecture/blob/main/rfcs/0002-well-known-attributes.md)


### PR DESCRIPTION
## Summary

Mark RFC 0017 (GRPCRoute Support) as **Implemented**. All 12 implementation tasks are now complete.

## Changes

- Update status from **Implementable** to **Implemented**
- Move Tasks 9-12 from Todo to Completed section with issue links
- Add FAQ section explaining HTTP to gRPC status code translation by Envoy

## Completed Tasks

- ✅ **Tasks 1-8:** Core operator infrastructure, policies, examples, and documentation
- ✅ **Task 9:** E2E test coverage ([testsuite#886](https://github.com/Kuadrant/testsuite/issues/886))
- ✅ **Task 10:** wasm-shim gRPC well-known attributes ([wasm-shim#317](https://github.com/Kuadrant/wasm-shim/issues/317))
- ✅ **Task 11:** Authorino gRPC well-known attributes ([authorino#584](https://github.com/Kuadrant/authorino/issues/584))
- ✅ **Task 12:** Console plugin UI support ([kuadrant-console-plugin#367](https://github.com/Kuadrant/kuadrant-console-plugin/issues/367))

## Additional Documentation

Added FAQ section addressing how Envoy handles HTTP-to-gRPC status code translation for policy rejections (AuthPolicy 401→UNAUTHENTICATED, RateLimitPolicy 429→UNAVAILABLE), including actual behaviour from user guide testing showing empty auth messages and "Too Many Requests" for rate limiting.

Resolves #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Marked gRPC route support feature as fully implemented
  * Expanded FAQ with detailed guidance on HTTP-to-gRPC status code translation, including mapping examples
  * Added comprehensive references for gRPC protocol specifications and Envoy architecture
  * Documented completion of gRPC test suites and attribute extraction implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/architecture/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->