### PR TITLE
RFC 0019: Kuadrant Operator Consolidation

### DIFF
--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -138,7 +138,11 @@ The operator does not create or modify cluster-scoped resources (CRDs, ClusterRo
 
 When a user creates a Kuadrant CR, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). The rendered namespaced resources are applied via Server-Side Apply with the kuadrant-operator as the field manager.
 
+Component controllers are deployed into the Kuadrant CR's namespace, not the kuadrant-operator's namespace. This is a change from the current model where all child operators run in `kuadrant-system` regardless of the Kuadrant CR's location. This approach moves towards supporting future multi-tenanted control plane scenarios.
+
 All component controller Deployments are owned by the Kuadrant CR via ownerReference. This includes dns-operator, which previously ran independently and did not require a Kuadrant CR.
+
+Observability (metrics collection, ServiceMonitors, log aggregation) must account for component controllers running in the Kuadrant CR's namespace rather than a fixed operator namespace.
 
 ## RBAC
 

--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -26,6 +26,7 @@ Consolidate the Kuadrant ecosystem into a single operator. The kuadrant-operator
 2. **Removing child operator controllers**: authorino-operator and limitador-operator continue to run as Deployments. Deferred to a follow-on RFC
 3. **Migrating to OLMv1**: all changes run on OLMv0. OLMv1 compatibility is a readiness outcome, not a migration step
 4. **Refactoring component Helm charts**: upstream charts are consumed as-is. Improved templating is future work
+5. **Conditional component deployment**: all components are always deployed. Optional component installation is future work
 
 # Motivation
 [motivation]: #motivation
@@ -36,9 +37,9 @@ OLMv1 [explicitly removes automatic dependency installation](https://github.com/
 
 > OLM v1 will not automatically install a missing dependency when a user requests an operator. The primary reasoning is that OLM v1 will err on the side of predictability and cluster-administrator awareness.
 
-Bundles declaring `olm.package.required`, `olm.gvk.required`, or `olm.constraint` will be rejected under OLMv1. Kuadrant's current model relies entirely on these declarations.
+Bundles declaring `olm.package.required`, `olm.gvk.required`, or `olm.constraint` will be rejected under OLMv1. Kuadrant's current model relies entirely on these declarations. This has been verified on OpenShift CRC: attempting to install the current kuadrant-operator via OLMv1 `ClusterExtension` fails with `bundle has a dependency declared via property "olm.package.required" which is currently not supported`.
 
-The exact process for transitioning a cluster (fully) from OLMv0 to OLMv1 is not yet documented — this is an open question that affects all operators, not just Kuadrant. Currently on OpenShift OLMv1 and OLMv0 run alongside each other. However, regardless of when or how that transition happens, the dependency resolution mechanism Kuadrant relies on will not exist in the future. We should eliminate our dependency declarations now, while still on OLMv0, so that Kuadrant is already compatible when the transition arrives.
+The exact process for transitioning a cluster (fully) from OLMv0 to OLMv1 is not yet documented. Currently on OpenShift OLMv1 and OLMv0 run alongside each other. However, regardless of when or how that transition happens, the dependency resolution mechanism Kuadrant relies on will not exist in the future. We should eliminate our dependency declarations now, while still on OLMv0, so that Kuadrant is already compatible when the transition arrives.
 
 ## Per-component OLM packaging adds overhead within a Kuadrant deployment
 
@@ -54,6 +55,10 @@ Kuadrant's deployment targets are not limited to OpenShift. In the future, we wa
 
 Each independent OLM operator requires its own bundle image, catalog entry, release pipeline, and version coordination. Consolidating into a single OLM package eliminates per-component release overhead while keeping the same controllers and workloads running on the cluster. No CRDs, Deployments, or other resources are removed or deprecated as part of this work.
 
+## Established pattern for OLMv1 readiness
+
+The meta-operator pattern (a parent operator deploying child components at runtime) is the approach highlighted by the OLM team for operators that previously relied on `olm.package.required` dependencies. It is already used in production by Red Hat OpenShift AI ([opendatahub-operator/rhods-operator](https://github.com/opendatahub-io/opendatahub-operator)) for 18+ components, and by the [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) which manages OLMv1's own sub-components using the same Helm SDK client-only rendering. The approach described in this RFC follows the same pattern, with the only difference being that charts are embedded in the operator image at build time rather than extracted from component images via init containers at runtime.
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
@@ -65,7 +70,7 @@ The kuadrant-operator becomes an umbrella operator that deploys component contro
 
 ## After
 
-1 OLM operator (kuadrant-operator) with a single CSV, bundle, and catalog entry. Component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway) are no longer OLM packages. They become internal controller deployments whose lifecycle is managed by the kuadrant-operator. No component controller bundles, catalogs, or CSVs need to be maintained.
+1 OLM operator (kuadrant-operator) with a single CSV, bundle, and catalog entry. Component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway) are no longer OLM packages. They become internal controller deployments whose lifecycle is managed by the kuadrant-operator at runtime via Helm chart rendering. No component controller bundles, catalogs, or CSVs need to be maintained.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -74,90 +79,79 @@ For visual diagrams covering the build-time chart sync, runtime reconciliation c
 
 ## Chart sync process
 
-Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A Go sync tool (`hack/sync-child-charts/`) downloads each chart, renders it using the Helm SDK, and classifies the rendered resources by kind. The output is split into three directories:
+Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A sync tool downloads each chart as-is and places it in the operator repo:
 
 ```text
-config/child-operators/
-├── crds/                         # Rendered CRDs (one file per component)
-│   ├── authorino-operator.yaml
-│   ├── limitador-operator.yaml
-│   ├── dns-operator.yaml
-│   └── mcp-gateway.yaml
-├── rbac/                         # Rendered ClusterRoles (one file per component)
-│   ├── authorino-operator.yaml
-│   ├── limitador-operator.yaml
-│   ├── dns-operator.yaml
-│   └── mcp-gateway.yaml
-└── charts/                       # Raw chart templates for runtime rendering
-    ├── authorino-operator/
-    ├── limitador-operator/
-    ├── dns-operator/
-    └── mcp-gateway/
+config/child-operators/charts/
+├── authorino-operator/     # Complete upstream chart
+├── limitador-operator/     # Complete upstream chart
+├── dns-operator/           # Complete upstream chart
+└── mcp-gateway/            # Complete upstream chart
 ```
 
-The separation serves a specific purpose:
+Charts are copied as-is from upstream with no rendering, splitting, or modification. The complete chart (Chart.yaml, values.yaml, templates/, crds/) is preserved so the operator can render it at runtime exactly as it would be used in a standalone Helm installation.
 
-- **`crds/` and `rbac/`** contain rendered output (real resource names, no Helm template expressions). These are included in the kuadrant-operator's OLM bundle and Helm chart via kustomize at build time. They are cluster-scoped resources managed by the installation method.
-- **`charts/`** contains the raw Helm chart templates (Chart.yaml, values.yaml, templates/) copied as-is from upstream. These are packaged into the operator container image and rendered at runtime when a Kuadrant CR is created.
-
-The sync tool handles both simple charts (single `manifests.yaml` generated by kustomize) and mature charts with full Helm templating (helpers, conditionals, configurable values). It renders to classify resources but preserves the raw templates for runtime use.
-
-Synced charts are committed to the repo. The sync is run manually via `make sync-child-operator-charts` when updating component versions.
-
-## Kuadrant-operator Helm chart
-
-The kuadrant-operator's own Helm chart (`charts/kuadrant-operator/`) should be updated to follow Helm best practices. Currently, it's a monolithic `manifests.yaml` generated by kustomize with all resources (including CRDs) inline in `templates/`. As part of this work, the chart should be restructured to use Helm's native `crds/` directory for all CRDs (kuadrant and component). This ensures correct install ordering (CRDs installed before templates) and aligns with Helm conventions.
+Synced charts are committed to the repo. The sync is run manually via `make sync-child-operator-charts` when updating component versions. Charts are also packaged into the operator container image for runtime access.
 
 ## Resource ownership
 
-Resource ownership is clearly split between the installation method and the operator:
+All child operator resources are managed by the kuadrant-operator at runtime. The only resources managed by the installer (OLM or Helm) are the kuadrant-operator's own resources:
 
 **Managed by the installer (Helm chart or OLM bundle):**
 
-| Resource | Source | Notes |
-|---|---|---|
-| All CRDs (kuadrant + component) | `config/child-operators/crds/` and `config/crd/` | Installed before the operator starts |
-| Component ClusterRoles | `config/child-operators/rbac/` | Installed before the operator starts |
-| kuadrant-operator Deployment | `config/manager/` | The operator itself |
-| kuadrant-operator ServiceAccount, ClusterRole, ClusterRoleBinding | `config/rbac/` | Operator's own RBAC |
+| Resource | Notes |
+|---|---|
+| kuadrant-operator CRDs | Kuadrant, AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, TokenRateLimitPolicy |
+| kuadrant-operator Deployment | The operator itself |
+| kuadrant-operator ServiceAccount, ClusterRole, ClusterRoleBinding | Operator's own RBAC |
+
+**Managed by the kuadrant-operator at runtime (on startup):**
+
+| Resource | Notes |
+|---|---|
+| Component CRDs | AuthConfig, Authorino, Limitador, DNSRecord, DNSHealthCheckProbe, MCPGatewayExtension, MCPServerRegistration, MCPVirtualServer |
+| Component ClusterRoles | All child operator ClusterRoles |
+| Component controller Deployments | authorino-operator, limitador-operator, dns-operator, mcp-gateway |
+| Component ServiceAccounts | Per-component identity |
+| Component ClusterRoleBindings | Binds component SAs to component ClusterRoles |
+| Component Roles, RoleBindings | Namespace-scoped RBAC (e.g. leader election) |
+| Component Services, ConfigMaps | Metrics, configuration |
 
 **Managed by the kuadrant-operator at runtime (triggered by Kuadrant CR creation):**
 
 | Resource | Notes |
 |---|---|
-| Component controller Deployments | authorino-operator, limitador-operator, dns-operator, mcp-gateway |
-| Component ServiceAccounts | Per-component identity |
-| Component ClusterRoleBindings | Binds component SAs to pre-installed ClusterRoles using `bind` |
-| Component Roles, RoleBindings | Namespace-scoped RBAC (e.g. leader election) |
-| Component Services, ConfigMaps | Metrics, configuration |
 | Wrapper CRs | Authorino CR, Limitador CR (reconciled by child operators into workloads) |
 
-The operator does not create or modify cluster-scoped resources (CRDs, ClusterRoles) at runtime. If a rendered chart produces a ClusterRole or CRD, the operator skips it with a log warning.
+Child operator CRDs are not included in the OLM bundle. This is a deliberate choice that eliminates GVK conflicts during OLM upgrades from the current multi-operator installation (see [Migration](#migration-from-multi-operator-olm-installation)).
 
 ## Runtime rendering
 
-When a user creates a Kuadrant CR, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). The rendered namespaced resources are applied via Server-Side Apply with the kuadrant-operator as the field manager.
+On startup, before the controller manager begins watching resources, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). This is the same pattern used by OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) and [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) in production.
 
-Component controllers are deployed into the Kuadrant CR's namespace, not the kuadrant-operator's namespace. This is a change from the current model where all child operators run in `kuadrant-system` regardless of the Kuadrant CR's location. This approach moves towards supporting future multi-tenanted control plane scenarios.
+Charts are rendered and applied following Helm's install ordering (CRDs first, then dependent resources). All child operator resources must be established before the controller manager starts watching for CRDs.
 
-All component controller Deployments are owned by the Kuadrant CR via ownerReference. This includes dns-operator, which previously ran independently and did not require a Kuadrant CR.
+Component controllers are deployed into the kuadrant-operator's namespace (e.g. `kuadrant-system`). They are control plane singletons, one instance per cluster, not per Kuadrant CR. This matches the current model where OLM deploys all child operators into the same namespace.
 
-Observability (metrics collection, ServiceMonitors, log aggregation) must account for component controllers running in the Kuadrant CR's namespace rather than a fixed operator namespace.
+Component controller Deployments are not owned by the Kuadrant CR. They run independently of whether a Kuadrant CR exists. The Kuadrant CR only triggers data plane resources (wrapper CRs, policies).
 
 ## RBAC
 
-The kuadrant-operator does not need to duplicate component controller permissions. The Kubernetes `bind` verb allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions. The operator's ClusterRole includes `bind` on each component's ClusterRole `resourceNames`. No `escalate` is needed since the operator does not modify ClusterRole rules at runtime; ClusterRoles are pre-installed by the installer (Helm or OLM bundle).
+The kuadrant-operator requires permissions to create and manage all child operator resources at runtime:
 
-Only ClusterRole names need tracking, not their contents. When a component controller changes its RBAC rules, no kuadrant-operator change is needed unless a ClusterRole is added or renamed.
+- **`apiextensions.k8s.io` CRDs**: unscoped `create` (required because the resource may not exist yet), plus `get`, `list`, `watch`, `update`, `patch` scoped to specific child CRD names via `resourceNames`. This ensures the operator can only modify CRDs it manages while limiting the broad permission to `create` only
+- **`rbac.authorization.k8s.io` ClusterRoles**: unscoped `create` (same reason as CRDs), plus `get`, `list`, `watch`, `update`, `patch`, `bind`, `escalate` scoped to specific child ClusterRole names via `resourceNames`
+- **`rbac.authorization.k8s.io` ClusterRoleBindings, Roles, RoleBindings**: standard CRUD to bind component SAs to their ClusterRoles
+- **`apps` Deployments, core resources**: standard CRUD for component controllers
 
-Component ClusterRoles must use fixed, predictable names. The `bind` permissions use `resourceNames`, so the operator must know the exact names at build time. Charts that derive ClusterRole names from the Helm release name (e.g. via the `fullname` helper) create a fragile dependency that can silently break the RBAC contract. The sync tool validates rendered ClusterRole names at sync time, catching any mismatches before they reach a cluster.
+The `escalate` verb on ClusterRoles is required because child operator ClusterRoles grant permissions (e.g. access to AuthConfig resources) that the kuadrant-operator itself does not hold. Without `escalate`, Kubernetes RBAC prevents creating a ClusterRole with rules the creator doesn't already have. The `bind` verb on ClusterRoles is also required because the charts render ClusterRoleBindings that reference those ClusterRoles. Without `bind`, Kubernetes RBAC prevents creating a binding to a ClusterRole whose permissions you don't hold.
 
 ## Two supported installation methods
 
-- **Helm**: Single `helm install` deploys everything. The kuadrant-operator Helm chart includes all CRDs (kuadrant and component) in its `crds/` directory following Helm best practices, and component ClusterRoles in `templates/`. CRDs and ClusterRoles are generated at `make helm-build` time from `config/child-operators/crds/` and `config/child-operators/rbac/` via kustomize.
-- **OLM**: Single operator in the catalog. The bundle includes all component CRDs and ClusterRoles (from `config/child-operators/` via `config/manifests/kustomization.yaml`). No component controller bundles in the catalog.
+- **Helm**: Single `helm install` deploys the kuadrant-operator and its own CRDs. The operator starts and deploys all child operator resources (CRDs, ClusterRoles, controllers) at runtime from embedded charts.
+- **OLM**: Single operator in the catalog. The bundle contains only the kuadrant-operator's own CRDs and Deployment. No child operator CRDs or ClusterRoles in the bundle. The operator deploys them at runtime, same as the Helm path.
 
-Both paths produce the same cluster state: CRDs and ClusterRoles installed, kuadrant-operator running, no component controllers until a Kuadrant CR is created.
+Both paths produce the same cluster state: kuadrant-operator running, child operator CRDs established, all component controllers deployed and running. Child operator resources are managed by the operator at runtime identically in both paths.
 
 ## Image references
 
@@ -172,35 +166,26 @@ OLM convention requires all container images to be declared in the CSV's `relate
 | `RELATED_IMAGE_DNS_OPERATOR` | `quay.io/kuadrant/dns-operator:latest` | DNS operator controller |
 | `RELATED_IMAGE_MCP_GATEWAY` | `ghcr.io/kuadrant/mcp-controller:latest` | MCP Gateway controller |
 
-These are declared as environment variables on the kuadrant-operator Deployment (`config/manager/manager.yaml`). The downstream build system overrides them with version-pinned or mirrored image references. The Helm reconcilers read these env vars and apply the correct images when rendering child operator charts, either by patching the rendered Deployment image directly (for simple charts that don't support values-based overrides) or by passing Helm values (for charts with configurable image fields).
+These are declared as environment variables on the kuadrant-operator Deployment (`config/manager/manager.yaml`). The downstream build system overrides them with version-pinned or mirrored image references. The Helm rendering reads these env vars and applies the correct images when rendering child operator charts, either by patching the rendered Deployment image directly (for simple charts that don't support values-based overrides) or by passing Helm values (for charts with configurable image fields).
 
 ## Wrapper CRs preserved
 
-Authorino CR and Limitador CR are still created by kuadrant-operator. Component controllers reconcile these wrapper CRs to create workloads. No change to this flow. Users see no difference in behaviour.
-
-## Kuadrant CR deletion must manage component lifecycle
-
-Component controller Deployments are owned by the Kuadrant CR via ownerReference. Several CRDs use finalizers that require their controller to be running:
-
-- Authorino CR has finalizer `authorino.kuadrant.io/finalizer`
-- DNSRecord CRs have finalizers for cleaning up external DNS provider records
-
-If the Kuadrant CR is deleted and the cascade deletes the controllers simultaneously, CRs with finalizers will be stuck in `Terminating` state. The kuadrant-operator must have a finalizer on the Kuadrant CR that enforces correct deletion order: ensure all controller-dependent resources with finalizers (wrapper CRs, DNSRecords, and any others) have completed their finalizer logic before allowing the cascade to remove component controller Deployments.
+Authorino CR and Limitador CR are still created by kuadrant-operator when a Kuadrant CR is created. Component controllers reconcile these wrapper CRs to create workloads. No change to this flow. Users see no difference in behaviour.
 
 ## OLM bundle and catalog
 
-The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. Component CRDs and ClusterRoles are included in the kuadrant-operator bundle directly from `config/child-operators/`. All component CRDs are declared as `owned` in the CSV, making kuadrant-operator the sole OLM owner. This requires a pre-upgrade cleanup step for existing multi-operator installations (see [Migration](#migration-from-multi-operator-olm-installation)).
+The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. The bundle contains only the kuadrant-operator's own CRDs and resources. Child operator CRDs are not included in the bundle; they are applied at runtime by the operator. This eliminates OLM GVK conflicts during upgrades from the current multi-operator installation.
 
 ## Component repos
 
-No changes are required in component repos for the consolidation to work. The sync tool will be designed to handle any chart structure.
+No changes are required in component repos for the consolidation to work. The sync tool downloads charts as-is.
 
 However, some upstream chart changes would be beneficial:
 
-- **CRDs directory**: charts that keep CRDs in `templates/` rather than the native Helm `crds/` directory could benefit from separating them, making the sync tool's job cleaner
 - **Consistent labels**: applying consistent labels across all component resources (e.g. `kuadrant.io/component`) would improve topology tracking and filtering. Currently, the Authorino Deployment lacks distinguishing labels, preventing it from being tracked in the kuadrant-operator topology
 - **Unique Deployment selectors**: the limitador-operator chart uses a generic `control-plane: controller-manager` selector that collides with the kuadrant-operator in the same namespace. This is a pre-existing bug that needs fixing upstream
 - **Fixed ClusterRole names**: charts using Helm's `fullname` helper for ClusterRole names create a fragile dependency on the release name. ClusterRoles are cluster-scoped permission definitions and should use fixed names
+- **Graceful CRD handling**: component controllers should handle missing CRDs gracefully (e.g. mcp-gateway currently crashes if Istio EnvoyFilter CRD is not installed)
 
 Since component repos no longer need to produce their own OLM bundles or catalogs, OLM-specific artefacts can also be removed to reduce maintenance burden: `bundle/`, `catalog/`, `config/manifests/`, `config/deploy/olm/`, `config/scorecard/`, `bundle.Dockerfile`, `operator-sdk` and `opm` tool dependencies.
 
@@ -216,100 +201,21 @@ Changes to the release process and version pinning strategy are out of scope for
 
 ## Migration from multi-operator OLM installation
 
-### The problem: OLM GVK conflict
+### How it works
 
-OLM's dependency resolver prevents two CSVs from providing the same GVK (Group-Version-Kind) within a namespace. When the consolidated kuadrant-operator bundle declares child CRDs (AuthConfig, Limitador, DNSRecord, etc.) as `owned`, the resolver sees a conflict with the still-installed child operator CSVs that also own those GVKs.
+Since child operator CRDs are not included in the OLM bundle, there are no GVK conflicts between the consolidated kuadrant-operator and the existing child operator CSVs. The OLM upgrade proceeds without stalling.
 
-This conflict manifests as a `ConstraintsNotSatisfiable` condition on the Subscription:
+On startup, the upgraded kuadrant-operator:
 
-```
-constraints not satisfiable: kuadrant-operator.v0.0.1 and dns-operator.v0.0.0
-provide DNSHealthCheckProbe (kuadrant.io/v1alpha1)
-```
+1. Applies child operator CRDs (which already exist from the previous installation)
+2. Deploys child operator controllers from embedded Helm charts
+3. Detects and removes orphaned child operator Subscriptions and CSVs programmatically
 
-The GVK properties are baked into the bundle by `opm render` from any CRDs present in the bundle image. They cannot be removed from the CSV `owned` list without also removing the CRDs from the bundle, and they cannot be removed from the `olm.gvk` catalog properties at all since `opm` generates them from the bundle content.
+The data plane (Authorino server, Limitador server) is unaffected throughout. Verified on OpenShift CRC: deleting child operator CSVs removes their controller Deployments but does not cascade-delete CRDs, ClusterRoles, or data plane workloads. The consolidated operator's child controllers take over seamlessly.
 
-The upgrade stalls safely: the existing deployment continues running, no data is lost, and the user has time to resolve the conflict.
+### OLMv1 compatibility
 
-### Chosen approach: documented migration cleanup
-
-The consolidated bundle declares all child CRDs as `owned`. The OLM upgrade stalls until the user removes the existing child operator Subscriptions and CSVs that conflict. This is a one-time migration step.
-
-In practice, the catalog update happens first (either pushed by an administrator or picked up automatically by OLM's catalog polling). The upgrade stalls safely, and the user then performs the cleanup to unblock it. For users who want full control over timing, setting `installPlanApproval: Manual` on the Subscription before the catalog update is recommended.
-
-**Migration steps:**
-
-```bash
-# 1. (Recommended) Set manual approval to control upgrade timing
-kubectl patch subscription kuadrant -n kuadrant-system \
-  --type=merge -p '{"spec":{"installPlanApproval":"Manual"}}'
-
-# 2. Remove child operator subscriptions (and mcp-gateway if installed standalone)
-kubectl delete subscription -n kuadrant-system \
-  authorino-operator-preview-kuadrant-operator-catalog-kuadrant-system \
-  dns-operator-preview-kuadrant-operator-catalog-kuadrant-system \
-  limitador-operator-preview-kuadrant-operator-catalog-kuadrant-system
-# If mcp-gateway was installed standalone:
-# kubectl delete subscription -n <namespace> <mcp-gateway-subscription-name>
-
-# 3. Remove child operator CSVs (and mcp-gateway if installed standalone)
-kubectl delete csv -n kuadrant-system \
-  authorino-operator.v0.0.0 \
-  dns-operator.v0.0.0 \
-  limitador-operator.v0.0.0
-# If mcp-gateway was installed standalone:
-# kubectl delete csv -n <namespace> <mcp-gateway-csv-name>
-
-# 4. If using manual approval, approve the install plan
-kubectl get installplan -n kuadrant-system
-kubectl patch installplan <name> -n kuadrant-system \
-  --type=merge -p '{"spec":{"approved":true}}'
-```
-
-**Tested behaviour** (verified on OpenShift CRC):
-
-1. Deleting child operator CSVs does **not** cascade-delete their CRDs. OLM tracks CRD ownership via labels (`operators.coreos.com/<operator>.<namespace>`) and annotations, not via Kubernetes ownerReferences. CRDs are cluster-scoped and CSVs are namespace-scoped, so Kubernetes cross-scope garbage collection does not apply.
-2. Deleting child CSVs **does** remove their managed Deployments (the child operator controllers stop).
-3. After cleanup, OLM resolves the upgrade and installs the consolidated bundle. The bundle re-installs all CRDs (updating them if schemas changed) and the kuadrant-operator deploys child controllers via Helm rendering.
-4. With automatic upgrades, the upgrade stalls with `ResolutionFailed` until the cleanup is performed. The existing deployment continues running with no data loss. Once the user performs the cleanup, the next resolver cycle (every few seconds) succeeds.
-
-The `ResolutionFailed` condition message clearly identifies the GVK conflict, making it straightforward to diagnose and point users at the migration documentation.
-
-### Alternatives considered for migration
-
-#### Transition release with runtime CRD management
-
-A stepping-stone release where the bundle contains no child CRDs. The operator applies CRDs at runtime, removes child subscriptions/CSVs programmatically, and sets OLM ownership labels. The next release then includes child CRDs as `owned` in the bundle.
-
-**Rejected because:**
-- Requires granting the operator `apiextensions.k8s.io` permissions to create/update CRDs. The `create` verb cannot be scoped by `resourceNames` (the resource doesn't exist yet), so it grants broad CRD creation ability.
-- Creates a window where child CRDs are unmanaged by OLM. No CSV declares them as `owned`, so OLM provides no protection against another operator claiming those GVKs.
-- Adds a release that exists solely for migration mechanics, increasing complexity.
-- The two-phase approach (transition + final) doubles the migration testing surface.
-
-#### Stripping child CRDs from CSV owned list
-
-Keep child CRDs in the bundle but remove them from the CSV's `spec.customresourcedefinitions.owned` list in a post-generation step. This avoids the GVK conflict at the CSV level.
-
-**Rejected because:**
-- `opm render` generates `olm.gvk` properties from CRDs present in the bundle image, regardless of what the CSV declares. The resolver uses these properties, not the CSV's `owned` list. Even with child CRDs stripped from `owned`, the resolver still sees the GVK conflict.
-- `operator-sdk bundle validate` rejects bundles where CRDs are present but not declared in the CSV. While validation can be skipped, it indicates the bundle is in an unsupported state.
-
-#### New API versions for child CRDs
-
-Introduce new API versions (e.g. `v1alpha2`) for child CRDs to avoid GVK overlap with existing child operator CSVs.
-
-**Rejected because:**
-- CRDs must still serve existing versions for backwards compatibility. A CRD serving both `v1alpha1` and `v1alpha2` still provides the `v1alpha1` GVK, which conflicts with the child CSV.
-- Creating new API versions purely for migration mechanics adds permanent API surface area for a transient problem.
-- Does not address the child subscription constraint (subscriptions pin child CSVs regardless of GVK overlap).
-
-### Other migration considerations
-
-- **Data plane continuity**: wrapper CRs (Authorino CR, Limitador CR) and their workloads are preserved throughout migration. Deleting child CSVs removes operator controllers but does not affect running workloads (Authorino server, Limitador server).
-- **Control plane gap**: between deleting child CSVs (which removes child controllers) and the consolidated operator starting (which redeploys them via Helm), there is a brief window where child controllers are not running. During this window, changes to wrapper CRs or child CRDs are not reconciled. Existing workloads continue running.
-- **Resource naming consistency**: resource names produced by the chart rendering should match names currently used by OLM-installed operators to avoid orphaned resources.
-- **Consistent labelling**: the umbrella operator can apply consistent labels to all managed resources, addressing existing gaps (e.g. Authorino Deployment lacks distinguishing labels for topology tracking).
+The consolidated bundle has been tested with OLMv1 `ClusterExtension` on OpenShift CRC and installs successfully. No dependency declarations, no GVK conflicts. This is in contrast to the current multi-operator bundle which is explicitly rejected by OLMv1: `bundle has a dependency declared via property "olm.package.required" which is currently not supported`.
 
 ### Upgrade testing
 
@@ -317,13 +223,11 @@ Automated upgrade tests must be established to validate the migration path from 
 
 - Start with the previous release installed via OLM (all 4 operators with their CSVs)
 - Create a Kuadrant CR with active policies and ingress traffic
-- Perform pre-upgrade cleanup (remove child subscriptions and CSVs)
 - Upgrade to the consolidated release via OLM catalog channel
+- Verify child operator Subscriptions and CSVs are cleaned up by the operator
 - Verify all child CRDs survived the migration
-- Verify kuadrant-operator CSV declares ownership of all CRDs
 - Verify all component controllers are running (now managed by kuadrant-operator)
 - Verify zero data plane disruption throughout (policies continue to be enforced, no traffic loss)
-- Verify CRD schema changes are applied correctly when present
 
 These tests should run in CI for every release and serve as ongoing regression testing for the OLM upgrade path.
 
@@ -333,16 +237,18 @@ These tests should run in CI for every release and serve as ongoing regression t
 This RFC deliberately preserves wrapper CRs and child operator controllers. A follow-on RFC should address further architectural simplification:
 
 - **Removing intermediate operator layers and wrapper CRs**: deploying Authorino and Limitador workloads directly from the kuadrant-operator, eliminating authorino-operator and limitador-operator as running controllers. This removes the `Authorino` and `Limitador` CRDs from the user-facing API surface. Each operator removed is a separate container image with its own Go dependency tree. Every transitive dependency is a potential CVE that needs scanning, patching, and releasing. Removing these controllers reduces the security surface area and maintenance burden.
+- **Control plane status CR**: a new cluster-scoped CR (e.g. `KuadrantControlPlane` or `KuadrantPlatform`, separate from the Kuadrant CR) for reporting child operator health and eventually enabling conditional component deployment. The operator would auto-create a default on startup. This separates control plane management (which components are deployed, their health) from data plane management (the Kuadrant CR, policies, workloads). This is the same pattern used by RHOAI/RHODS, where `DSCInitialization` handles platform setup and `DataScienceCluster` controls component lifecycle.
+- **Conditional component deployment**: using the control plane CR to allow operators to be selectively enabled or disabled, avoiding deploying components that are not needed (e.g. mcp-gateway on clusters without Istio).
 - **Extracting a dedicated policy controller**: separating policy reconciliation (AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy) from the kuadrant-operator into a `kuadrant-policy-controller` deployed as a component, making the kuadrant-operator purely an orchestration layer.
-- **Selective component installation**: adding `spec.components` to the Kuadrant CRD for user-facing control over which components are deployed.
 - **Kuadrant CR evolution**: exposing day 2 configuration (replicas, resources, storage backend) through the Kuadrant CR.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- **Broader RBAC for kuadrant-operator**: the kuadrant-operator now needs permissions to manage Deployments, Services, RBAC, and ConfigMaps for all component controllers, plus `bind` on their ClusterRoles.
+- **Broader RBAC for kuadrant-operator**: the kuadrant-operator needs an unscoped `create` on `apiextensions.k8s.io` CRDs (scoped `create` is not possible in Kubernetes RBAC since the resource does not exist yet) and `escalate` on ClusterRoles. All other CRD verbs (`get`, `update`, `patch`) are scoped to specific child CRD names. These permissions follow the same pattern used by the OpenShift [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) and [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) in production.
 - **Chart sync maintenance**: component controller charts must be kept in sync. Automated dependency sync (via GitHub dispatch) mitigates this but adds CI complexity.
-- **Finalizer ordering**: the Kuadrant CR must manage deletion order to prevent wrapper CR finalizers from being orphaned. This adds reconciliation complexity.
+- **No OLM CRD protection**: OLM does not know about child operator CRDs, so it cannot prevent another OLM-managed operator from claiming the same GVKs. In practice, this is a narrow risk: it requires installing a standalone child operator via OLM alongside kuadrant, which is a user error. It is worth noting that OLM's GVK protection only prevents conflicts between OLM-managed packages. It does nothing to prevent a Helm chart or raw manifest from altering or replacing a CRD on the cluster.
+- **Startup failure is fatal**: if a child operator chart is malformed or the cluster rejects a resource, the kuadrant-operator will not start. This is a feature, not a bug: it prevents partially-upgraded states where some components are on the new version and others are not. The previous operator pod continues running until the new one is healthy (Deployment rollout strategy).
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -351,11 +257,35 @@ This RFC deliberately preserves wrapper CRs and child operator controllers. A fo
 
 - **No new operator**: the kuadrant-operator itself becomes the umbrella operator, avoiding a new codebase, image, CI pipeline, and release process.
 - **No breaking changes**: wrapper CRs are preserved. Wrapper CR removal is deferred to a follow-on RFC when it can be properly investigated and tested.
-- **Helm as first-class citizen**: both installation paths (direct Helm and OLM) consume the same charts, unifying upstream and downstream experiences.
+- **Helm as first-class citizen**: both installation paths (direct Helm and OLM) use the same charts. The kuadrant-operator Helm chart is fully visible to Helm for its own resources. Child operator resources are rendered from the same upstream charts in both paths.
+- **No OLM migration friction**: child operator CRDs are not in the bundle, so OLM GVK conflicts do not occur. The upgrade proceeds automatically and the operator handles cleanup of orphaned child Subscriptions/CSVs.
+- **OLMv1 ready**: verified working with OLMv1 `ClusterExtension` on OpenShift CRC. No dependency declarations, no GVK conflicts.
 - **Reduced operator footprint**: the OLM catalog goes from 4 packages to 1. Component repos can remove all OLM-specific artefacts.
-- **Proven pattern**: OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) uses Helm client-only rendering in production.
+- **Proven pattern**: OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) uses identical Helm SDK client-only rendering (`ClientOnly=true`, `DryRun=true`, `action.NewInstall`) to deploy sub-components in production. The [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) uses a similar manifest-based approach for 18+ components.
+- **Path to further simplification**: the runtime rendering infrastructure enables future conditional component deployment and will be reused when child operators are flattened (deploying Authorino/Limitador workloads directly from their Helm charts).
 
 ## Alternatives considered
+
+#### Installer-managed CRDs and ClusterRoles (split chart approach)
+
+The chart sync tool renders each upstream chart, classifies resources by kind, and splits them into separate directories: `crds/` and `rbac/` for installer-managed resources, `charts/` for runtime rendering. CRDs and ClusterRoles are included in the OLM bundle and Helm chart at build time. The operator only renders namespaced resources (Deployments, SAs, etc.) at runtime, skipping CRDs and ClusterRoles.
+
+**Rejected because:**
+- Including child CRDs in the OLM bundle causes GVK conflicts during upgrades from the current multi-operator installation. `opm render` bakes `olm.gvk` properties from any CRDs in the bundle image, and the resolver blocks the upgrade when those GVKs are already provided by existing child operator CSVs. OLM provides no visible error when the upgrade is blocked; the subscription silently stays at `AtLatestKnown` with no indication that an upgrade is available but stalled.
+- Splits the chart into installer-managed and runtime-managed resources, diverging from how the chart would be used in a standalone Helm installation. This creates two different deployment models for the same component.
+- For the Helm install path, CRDs and ClusterRoles must be extracted into the kuadrant-operator Helm chart at build time while the operator renders the rest at runtime. Helm has no visibility of the runtime-managed resources.
+- Tightly couples the sync tool to chart internals. The tool must render and classify resources by kind, and changes to chart structure can silently produce incorrect classification.
+- No path to conditional component deployment. CRDs and ClusterRoles are installed at install time regardless of whether the component is needed.
+
+#### Consolidated CSV (large CSV approach)
+
+All child operator resources (CRDs, ClusterRoles, Deployments, SAs, RBAC) included directly in the kuadrant-operator CSV as static manifests. No runtime rendering. OLM and Helm both deploy the complete set of resources at install time. The existing `config/dependencies/` kustomize references are wired into the bundle and Helm chart build paths.
+
+**Rejected because:**
+- Same OLM GVK conflict as the split chart approach: child CRDs in the bundle cause `opm render` to bake GVK properties that conflict with existing child operator CSVs, blocking upgrades.
+- For the Helm install path, child operator resources need to be duplicated or the Helm chart needs to pull from the same kustomize source as the bundle, coupling the two paths and producing the same cluster state through different mechanisms.
+- All components always deployed with no path to conditional installation. Components that depend on cluster prerequisites (e.g. mcp-gateway requires Istio) cannot be excluded.
+- Does not establish the runtime rendering infrastructure needed for future work (flattening child operators, deploying data plane workloads directly from their Helm charts).
 
 #### New umbrella operator (separate from kuadrant-operator)
 
@@ -366,24 +296,16 @@ A separate operator that coordinates deployment while kuadrant-operator handles 
 - Two operators to debug (deployment issues vs policy issues).
 - The kuadrant-operator already has the Kuadrant CR watch, the topology, and the workflow infrastructure. Adding Helm rendering to it is simpler than building a new operator that needs all the same context.
 
-#### New umbrella operator with kuadrant-operator as policy controller
+#### Operator-managed Subscriptions
 
-Introduce a new umbrella operator for deployment orchestration. The existing kuadrant-operator becomes a pure policy controller deployed as a component, and the new operator takes ownership of the Kuadrant CR.
-
-**Rejected because:**
-- Introduces a new codebase, image, CI pipeline, and release process.
-- The kuadrant-operator already has the Kuadrant CR watch, the topology, and the workflow infrastructure. Adding Helm rendering to it is simpler than building a new operator that needs all the same context.
-- Two operators to debug (deployment issues vs policy issues).
-- Splitting policy reconciliation out of the kuadrant-operator can still be done as a future phase if needed, without requiring a new operator to be built first.
-
-#### Large CSV
-
-A single OLM bundle containing all existing operators in one CSV with zero dependency declarations.
+The kuadrant-operator creates OLM Subscription resources for each child operator at runtime, either programmatically or via resources included in the bundle. OLM then installs the child operators from the catalog as it does today, but triggered by the operator rather than by `dependencies.yaml`.
 
 **Rejected because:**
-- Dependency operators are retained. Their maintenance cost, security surface area, and release complexity remain.
-- OLM owns all Deployments in the CSV and reconciles them back to the declared state. Users cannot scale replicas or adjust resources without rebuilding the bundle.
-- Does not put Helm at the centre of installation.
+- `Subscription` is an OLMv0 resource that is replaced by `ClusterExtension` in OLMv1. The operator would need to handle both APIs or be rewritten when OLMv1 becomes the default.
+- Only works on clusters with OLM installed. For Helm installs on vanilla Kubernetes (EKS, GKE, AKS), child operators are installed via Helm chart dependencies. This means two completely separate code paths for deploying the same components, and the operator would need to detect which mechanism is in use.
+- Child operator bundles, catalogs, and release pipelines all remain. The only thing removed is `dependencies.yaml`, so the per-component release overhead is unchanged.
+- Still results in multiple CSVs and Subscriptions on the cluster, with no single view of product health.
+- While simpler as a first step, it does not contribute to the longer-term goal of consolidating operators. The Subscription management code would be discarded when child operators are eventually absorbed into kuadrant-operator.
 
 #### Manual installation of dependencies
 
@@ -397,7 +319,9 @@ Each component published as its own independent OLM package with no dependency d
 # Prior art
 [prior-art]: #prior-art
 
-- **[cluster-olm-operator](https://github.com/openshift/cluster-olm-operator)**: manages OLMv1 sub-components using Helm charts rendered client-only.
+- **[cluster-olm-operator](https://github.com/openshift/cluster-olm-operator)**: manages OLMv1 sub-components using Helm charts rendered client-only. Uses init containers to extract charts from component images at pod startup, renders with the same Helm SDK pattern (`ClientOnly=true`, `DryRun=true`, `action.NewInstall`). Our approach embeds charts at build time instead, but the runtime rendering is identical. Deployed in production OpenShift.
+- **[opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator)** (downstream: [rhods-operator](https://github.com/red-hat-data-services/rhods-operator), Red Hat OpenShift AI): manages 18+ component controllers via manifests fetched from upstream repos at build time and applied at runtime. Uses `DataScienceCluster` CR with `managementState` per component for conditional deployment. Highlighted by the OLM team as a reference implementation for operators that need other operators present on the cluster without using OLM dependency declarations.
+- **[OpenShift Ingress Operator](https://github.com/openshift/cluster-ingress-operator)**: deploys Istio control plane (including CRDs like EnvoyFilter) at runtime triggered by a GatewayClass CR. Another example of a core OpenShift operator managing CRDs and controllers at runtime without OLM involvement.
 - **[OLMv0 dependency resolution](https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/)**: the current model being replaced.
 - **[OLMv1 design decisions](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md)**: documents why dependency resolution was removed.
 
@@ -406,6 +330,8 @@ Each component published as its own independent OLM package with no dependency d
 
 - **OLMv0 to OLMv1 cluster transition**: the exact process for migrating a cluster from OLMv0 to OLMv1 is not documented. The umbrella operator approach ensures Kuadrant is ready regardless of how this transition works.
 
-- **CRD ownership conflicts with standalone installations**: if standalone Authorino is already installed on a cluster, the kuadrant-operator's bundle includes Authorino CRDs. Under OLMv1's single-ownership model, two bundles cannot own the same CRDs. This is the same GVK conflict pattern as the migration scenario, and would require the standalone operator to be removed first.
+- **CRD ownership conflicts with standalone installations**: if standalone Authorino is already installed on a cluster, the kuadrant-operator will apply the same CRDs via SSA with `Force: true`, potentially overwriting the standalone version. This is a user error scenario (installing two things that manage the same CRDs) but could cause unexpected behaviour if the versions differ.
 
 - **Wrapper CR removal timeline**: this RFC preserves wrapper CRs. The timeline and approach for removing them depends on how much the Authorino and Limitador CRs are used for direct user customisation vs being purely internal. This will be addressed in a follow-on RFC.
+
+- **Control plane status and configuration CR**: the RFC identifies the need for a new CR to report child operator health and eventually enable conditional deployment, but the design of this CR is deferred to implementation.

--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -40,9 +40,11 @@ Bundles declaring `olm.package.required`, `olm.gvk.required`, or `olm.constraint
 
 The exact process for transitioning a cluster (fully) from OLMv0 to OLMv1 is not yet documented — this is an open question that affects all operators, not just Kuadrant. Currently on OpenShift OLMv1 and OLMv0 run alongside each other. However, regardless of when or how that transition happens, the dependency resolution mechanism Kuadrant relies on will not exist in the future. We should eliminate our dependency declarations now, while still on OLMv0, so that Kuadrant is already compatible when the transition arrives.
 
-## Dependency operators exist to satisfy OLM packaging requirements
+## Per-component OLM packaging adds overhead within a Kuadrant deployment
 
-These dependency operators (authorino-operator, limitador-operator) exist because OLMv0 required each component to be packaged as its own operator with its own CSV, Subscription, and CRD. They were created to satisfy this packaging requirement, not because the workloads they manage have complex lifecycle needs. Each maintains its own release pipeline, bundle images, and catalog entries. Consolidating them under the kuadrant-operator eliminates this per-component overhead.
+Authorino, Limitador, and mcp-gateway are independent projects with standalone use cases outside Kuadrant. Their operators were created in part to support independent installation and lifecycle management. However, within a Kuadrant deployment, they function as internal components whose lifecycle is tied to the Kuadrant CR. The per-component OLM packaging (separate CSV, Subscription, bundle image, catalog entry, release pipeline) adds overhead that is only justified when the components are deployed independently.
+
+This RFC consolidates the Kuadrant-as-a-product installation path. The individual component repos and their Helm charts remain available for standalone installation. Nothing prevents a user from installing just Limitador or just Authorino directly from their own repos.
 
 ## Kuadrant needs to run beyond OpenShift
 
@@ -125,7 +127,7 @@ Resource ownership is clearly split between the installation method and the oper
 |---|---|
 | Component controller Deployments | authorino-operator, limitador-operator, dns-operator, mcp-gateway |
 | Component ServiceAccounts | Per-component identity |
-| Component ClusterRoleBindings | Binds component SAs to pre-installed ClusterRoles using `bind`/`escalate` |
+| Component ClusterRoleBindings | Binds component SAs to pre-installed ClusterRoles using `bind` |
 | Component Roles, RoleBindings | Namespace-scoped RBAC (e.g. leader election) |
 | Component Services, ConfigMaps | Metrics, configuration |
 | Wrapper CRs | Authorino CR, Limitador CR (reconciled by child operators into workloads) |
@@ -140,13 +142,11 @@ All component controller Deployments are owned by the Kuadrant CR via ownerRefer
 
 ## RBAC
 
-The kuadrant-operator does not need to duplicate component controller permissions. The Kubernetes `bind` verb allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions. The operator's ClusterRole includes `bind`/`escalate` on each component's ClusterRole `resourceNames`.
-
-`bind` is sufficient for steady-state runtime operation (creating ClusterRoleBindings). `escalate` is retained for migration scenarios where the operator may need to update existing ClusterRole rules to align with the consolidated model. Whether rule changes are needed depends on the migration implementation. If migration only requires metadata updates (annotations, labels), `escalate` can be removed.
+The kuadrant-operator does not need to duplicate component controller permissions. The Kubernetes `bind` verb allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions. The operator's ClusterRole includes `bind` on each component's ClusterRole `resourceNames`. No `escalate` is needed since the operator does not modify ClusterRole rules at runtime; ClusterRoles are pre-installed by the installer (Helm or OLM bundle).
 
 Only ClusterRole names need tracking, not their contents. When a component controller changes its RBAC rules, no kuadrant-operator change is needed unless a ClusterRole is added or renamed.
 
-Component ClusterRoles must use fixed, predictable names. The `bind`/`escalate` permissions use `resourceNames`, so the operator must know the exact names at build time. Charts that derive ClusterRole names from the Helm release name (e.g. via the `fullname` helper) create a fragile dependency that can silently break the RBAC contract. The sync tool validates rendered ClusterRole names at sync time, catching any mismatches before they reach a cluster.
+Component ClusterRoles must use fixed, predictable names. The `bind` permissions use `resourceNames`, so the operator must know the exact names at build time. Charts that derive ClusterRole names from the Helm release name (e.g. via the `fullname` helper) create a fragile dependency that can silently break the RBAC contract. The sync tool validates rendered ClusterRole names at sync time, catching any mismatches before they reach a cluster.
 
 ## Two supported installation methods
 
@@ -154,6 +154,21 @@ Component ClusterRoles must use fixed, predictable names. The `bind`/`escalate` 
 - **OLM**: Single operator in the catalog. The bundle includes all component CRDs and ClusterRoles (from `config/child-operators/` via `config/manifests/kustomization.yaml`). No component controller bundles in the catalog.
 
 Both paths produce the same cluster state: CRDs and ClusterRoles installed, kuadrant-operator running, no component controllers until a Kuadrant CR is created.
+
+## Image references
+
+OLM convention requires all container images to be declared in the CSV's `relatedImages` section and as `RELATED_IMAGE_*` environment variables on the operator Deployment. This is used for image mirroring in disconnected environments, version pinning at release time, and downstream build system automation. The consolidated kuadrant-operator CSV must include all component images that were previously declared in individual operator CSVs:
+
+| Env var | Default image | Purpose |
+|---|---|---|
+| `RELATED_IMAGE_AUTHORINO_OPERATOR` | `quay.io/kuadrant/authorino-operator:latest` | Authorino operator controller |
+| `RELATED_IMAGE_AUTHORINO` | `quay.io/kuadrant/authorino:latest` | Authorino workload |
+| `RELATED_IMAGE_LIMITADOR_OPERATOR` | `quay.io/kuadrant/limitador-operator:latest` | Limitador operator controller |
+| `RELATED_IMAGE_LIMITADOR` | `quay.io/kuadrant/limitador:latest` | Limitador workload |
+| `RELATED_IMAGE_DNS_OPERATOR` | `quay.io/kuadrant/dns-operator:latest` | DNS operator controller |
+| `RELATED_IMAGE_MCP_GATEWAY` | `ghcr.io/kuadrant/mcp-controller:latest` | MCP Gateway controller |
+
+These are declared as environment variables on the kuadrant-operator Deployment (`config/manager/manager.yaml`). The downstream build system overrides them with version-pinned or mirrored image references. The Helm reconcilers read these env vars and apply the correct images when rendering child operator charts, either by patching the rendered Deployment image directly (for simple charts that don't support values-based overrides) or by passing Helm values (for charts with configurable image fields).
 
 ## Wrapper CRs preserved
 
@@ -170,7 +185,7 @@ If the Kuadrant CR is deleted and the cascade deletes the controllers simultaneo
 
 ## OLM bundle and catalog
 
-The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. Component CRDs and ClusterRoles are included in the kuadrant-operator bundle directly from `config/child-operators/`.
+The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. Component CRDs and ClusterRoles are included in the kuadrant-operator bundle directly from `config/child-operators/`. All component CRDs are declared as `owned` in the CSV, making kuadrant-operator the sole OLM owner. This requires a pre-upgrade cleanup step for existing multi-operator installations (see [Migration](#migration-from-multi-operator-olm-installation)).
 
 ## Component repos
 
@@ -187,16 +202,126 @@ Since component repos no longer need to produce their own OLM bundles or catalog
 
 ## Automated dependency sync
 
-Component repos need automation to notify the kuadrant-operator when their charts change. A pattern already exists between authorino and authorino-operator: push to main triggers a `repository_dispatch` to the downstream repo, which runs the sync tool and creates a PR.
+With the kuadrant-operator consuming charts from multiple child repos, automation is needed to keep them in sync. A pattern for this already exists between authorino and authorino-operator: push to main triggers a `repository_dispatch` to the downstream repo, which runs the sync tool and creates a PR.
 
-## Migration considerations
+The same pattern should be adopted for the kuadrant-operator. When a child repo's CI completes successfully on a tracked branch, it dispatches to the kuadrant-operator. The sync tool runs, and if there are changes, a PR is created or updated. The automation should manage a single open PR per target branch and child component (e.g. `sync/main/authorino-operator`, `sync/release-v1.5/authorino-operator`), force-updating it on each trigger rather than accumulating stale PRs.
 
-- **CRD ownership transfer**: OLM tracks CRD ownership via annotations. These need updating during the transition.
-- **Orphaned OLM resources**: OLM will not automatically uninstall previously resolved child operators. Subscriptions, CSVs, and associated resources must be explicitly cleaned up.
-- **Control plane resource conflicts**: existing Deployments may have different field managers (OLM vs SSA). The safest approach is to delete old control plane resources before upgrade. This does not affect the data plane.
-- **Data plane continuity**: wrapper CRs must be preserved throughout migration. Their workloads continue running uninterrupted.
+This automation must support not just `main` but also `release-*` branches. Multiple kuadrant-operator release branches may track different branches of the same child component. For example, `kuadrant-operator/main` may track `authorino-operator/main` while `kuadrant-operator/release-v1.5` tracks `authorino-operator/release-v1.5`.
+
+Changes to the release process and version pinning strategy are out of scope for this RFC and will be addressed separately.
+
+## Migration from multi-operator OLM installation
+
+### The problem: OLM GVK conflict
+
+OLM's dependency resolver prevents two CSVs from providing the same GVK (Group-Version-Kind) within a namespace. When the consolidated kuadrant-operator bundle declares child CRDs (AuthConfig, Limitador, DNSRecord, etc.) as `owned`, the resolver sees a conflict with the still-installed child operator CSVs that also own those GVKs.
+
+This conflict manifests as a `ConstraintsNotSatisfiable` condition on the Subscription:
+
+```
+constraints not satisfiable: kuadrant-operator.v0.0.1 and dns-operator.v0.0.0
+provide DNSHealthCheckProbe (kuadrant.io/v1alpha1)
+```
+
+The GVK properties are baked into the bundle by `opm render` from any CRDs present in the bundle image. They cannot be removed from the CSV `owned` list without also removing the CRDs from the bundle, and they cannot be removed from the `olm.gvk` catalog properties at all since `opm` generates them from the bundle content.
+
+The upgrade stalls safely: the existing deployment continues running, no data is lost, and the user has time to resolve the conflict.
+
+### Chosen approach: documented migration cleanup
+
+The consolidated bundle declares all child CRDs as `owned`. The OLM upgrade stalls until the user removes the existing child operator Subscriptions and CSVs that conflict. This is a one-time migration step.
+
+In practice, the catalog update happens first (either pushed by an administrator or picked up automatically by OLM's catalog polling). The upgrade stalls safely, and the user then performs the cleanup to unblock it. For users who want full control over timing, setting `installPlanApproval: Manual` on the Subscription before the catalog update is recommended.
+
+**Migration steps:**
+
+```bash
+# 1. (Recommended) Set manual approval to control upgrade timing
+kubectl patch subscription kuadrant -n kuadrant-system \
+  --type=merge -p '{"spec":{"installPlanApproval":"Manual"}}'
+
+# 2. Remove child operator subscriptions (and mcp-gateway if installed standalone)
+kubectl delete subscription -n kuadrant-system \
+  authorino-operator-preview-kuadrant-operator-catalog-kuadrant-system \
+  dns-operator-preview-kuadrant-operator-catalog-kuadrant-system \
+  limitador-operator-preview-kuadrant-operator-catalog-kuadrant-system
+# If mcp-gateway was installed standalone:
+# kubectl delete subscription -n <namespace> <mcp-gateway-subscription-name>
+
+# 3. Remove child operator CSVs (and mcp-gateway if installed standalone)
+kubectl delete csv -n kuadrant-system \
+  authorino-operator.v0.0.0 \
+  dns-operator.v0.0.0 \
+  limitador-operator.v0.0.0
+# If mcp-gateway was installed standalone:
+# kubectl delete csv -n <namespace> <mcp-gateway-csv-name>
+
+# 4. If using manual approval, approve the install plan
+kubectl get installplan -n kuadrant-system
+kubectl patch installplan <name> -n kuadrant-system \
+  --type=merge -p '{"spec":{"approved":true}}'
+```
+
+**Tested behaviour** (verified on OpenShift CRC):
+
+1. Deleting child operator CSVs does **not** cascade-delete their CRDs. OLM tracks CRD ownership via labels (`operators.coreos.com/<operator>.<namespace>`) and annotations, not via Kubernetes ownerReferences. CRDs are cluster-scoped and CSVs are namespace-scoped, so Kubernetes cross-scope garbage collection does not apply.
+2. Deleting child CSVs **does** remove their managed Deployments (the child operator controllers stop).
+3. After cleanup, OLM resolves the upgrade and installs the consolidated bundle. The bundle re-installs all CRDs (updating them if schemas changed) and the kuadrant-operator deploys child controllers via Helm rendering.
+4. With automatic upgrades, the upgrade stalls with `ResolutionFailed` until the cleanup is performed. The existing deployment continues running with no data loss. Once the user performs the cleanup, the next resolver cycle (every few seconds) succeeds.
+
+The `ResolutionFailed` condition message clearly identifies the GVK conflict, making it straightforward to diagnose and point users at the migration documentation.
+
+### Alternatives considered for migration
+
+#### Transition release with runtime CRD management
+
+A stepping-stone release where the bundle contains no child CRDs. The operator applies CRDs at runtime, removes child subscriptions/CSVs programmatically, and sets OLM ownership labels. The next release then includes child CRDs as `owned` in the bundle.
+
+**Rejected because:**
+- Requires granting the operator `apiextensions.k8s.io` permissions to create/update CRDs. The `create` verb cannot be scoped by `resourceNames` (the resource doesn't exist yet), so it grants broad CRD creation ability.
+- Creates a window where child CRDs are unmanaged by OLM. No CSV declares them as `owned`, so OLM provides no protection against another operator claiming those GVKs.
+- Adds a release that exists solely for migration mechanics, increasing complexity.
+- The two-phase approach (transition + final) doubles the migration testing surface.
+
+#### Stripping child CRDs from CSV owned list
+
+Keep child CRDs in the bundle but remove them from the CSV's `spec.customresourcedefinitions.owned` list in a post-generation step. This avoids the GVK conflict at the CSV level.
+
+**Rejected because:**
+- `opm render` generates `olm.gvk` properties from CRDs present in the bundle image, regardless of what the CSV declares. The resolver uses these properties, not the CSV's `owned` list. Even with child CRDs stripped from `owned`, the resolver still sees the GVK conflict.
+- `operator-sdk bundle validate` rejects bundles where CRDs are present but not declared in the CSV. While validation can be skipped, it indicates the bundle is in an unsupported state.
+
+#### New API versions for child CRDs
+
+Introduce new API versions (e.g. `v1alpha2`) for child CRDs to avoid GVK overlap with existing child operator CSVs.
+
+**Rejected because:**
+- CRDs must still serve existing versions for backwards compatibility. A CRD serving both `v1alpha1` and `v1alpha2` still provides the `v1alpha1` GVK, which conflicts with the child CSV.
+- Creating new API versions purely for migration mechanics adds permanent API surface area for a transient problem.
+- Does not address the child subscription constraint (subscriptions pin child CSVs regardless of GVK overlap).
+
+### Other migration considerations
+
+- **Data plane continuity**: wrapper CRs (Authorino CR, Limitador CR) and their workloads are preserved throughout migration. Deleting child CSVs removes operator controllers but does not affect running workloads (Authorino server, Limitador server).
+- **Control plane gap**: between deleting child CSVs (which removes child controllers) and the consolidated operator starting (which redeploys them via Helm), there is a brief window where child controllers are not running. During this window, changes to wrapper CRs or child CRDs are not reconciled. Existing workloads continue running.
 - **Resource naming consistency**: resource names produced by the chart rendering should match names currently used by OLM-installed operators to avoid orphaned resources.
 - **Consistent labelling**: the umbrella operator can apply consistent labels to all managed resources, addressing existing gaps (e.g. Authorino Deployment lacks distinguishing labels for topology tracking).
+
+### Upgrade testing
+
+Automated upgrade tests must be established to validate the migration path from the current multi-operator OLM installation to the consolidated operator. These tests should:
+
+- Start with the previous release installed via OLM (all 4 operators with their CSVs)
+- Create a Kuadrant CR with active policies and ingress traffic
+- Perform pre-upgrade cleanup (remove child subscriptions and CSVs)
+- Upgrade to the consolidated release via OLM catalog channel
+- Verify all child CRDs survived the migration
+- Verify kuadrant-operator CSV declares ownership of all CRDs
+- Verify all component controllers are running (now managed by kuadrant-operator)
+- Verify zero data plane disruption throughout (policies continue to be enforced, no traffic loss)
+- Verify CRD schema changes are applied correctly when present
+
+These tests should run in CI for every release and serve as ongoing regression testing for the OLM upgrade path.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
@@ -211,7 +336,7 @@ This RFC deliberately preserves wrapper CRs and child operator controllers. A fo
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- **Broader RBAC for kuadrant-operator**: the kuadrant-operator now needs permissions to manage Deployments, Services, RBAC, and ConfigMaps for all component controllers, plus `bind`/`escalate` on their ClusterRoles.
+- **Broader RBAC for kuadrant-operator**: the kuadrant-operator now needs permissions to manage Deployments, Services, RBAC, and ConfigMaps for all component controllers, plus `bind` on their ClusterRoles.
 - **Chart sync maintenance**: component controller charts must be kept in sync. Automated dependency sync (via GitHub dispatch) mitigates this but adds CI complexity.
 - **Finalizer ordering**: the Kuadrant CR must manage deletion order to prevent wrapper CR finalizers from being orphaned. This adds reconciliation complexity.
 
@@ -277,8 +402,6 @@ Each component published as its own independent OLM package with no dependency d
 
 - **OLMv0 to OLMv1 cluster transition**: the exact process for migrating a cluster from OLMv0 to OLMv1 is not documented. The umbrella operator approach ensures Kuadrant is ready regardless of how this transition works.
 
-- **OLMv0 behaviour when a CSV drops dependency declarations**: when the kuadrant-operator CSV is upgraded to a version that removes its `olm.package.required` declarations, what happens to the dependency Subscriptions/CSVs that OLMv0 auto-installed? The OLMv1 design doc states they are not automatically removed, but this needs verification.
-
-- **CRD ownership conflicts with standalone installations**: if standalone Authorino is already installed on a cluster, the kuadrant-operator's bundle includes Authorino CRDs. Under OLMv1's single-ownership model, two bundles cannot own the same CRDs.
+- **CRD ownership conflicts with standalone installations**: if standalone Authorino is already installed on a cluster, the kuadrant-operator's bundle includes Authorino CRDs. Under OLMv1's single-ownership model, two bundles cannot own the same CRDs. This is the same GVK conflict pattern as the migration scenario, and would require the standalone operator to be removed first.
 
 - **Wrapper CR removal timeline**: this RFC preserves wrapper CRs. The timeline and approach for removing them depends on how much the Authorino and Limitador CRs are used for direct user customisation vs being purely internal. This will be addressed in a follow-on RFC.

--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -2,7 +2,7 @@
 
 - Feature Name: `kuadrant_operator_consolidation`
 - Start Date: 2026-06-11
-- RFC PR: [Kuadrant/architecture#0000](https://github.com/Kuadrant/architecture/pull/0000)
+- RFC PR: [Kuadrant/architecture#189](https://github.com/Kuadrant/architecture/pull/189)
 - Issue tracking: [Kuadrant/architecture#164](https://github.com/Kuadrant/architecture/issues/164)
 
 # Summary
@@ -30,7 +30,7 @@ Consolidate the Kuadrant ecosystem into a single operator. The kuadrant-operator
 # Motivation
 [motivation]: #motivation
 
-### OLM dependency resolution is being removed
+## OLM dependency resolution is being removed
 
 OLMv1 [explicitly removes automatic dependency installation](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md). The [design decisions document](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md) states:
 
@@ -40,15 +40,15 @@ Bundles declaring `olm.package.required`, `olm.gvk.required`, or `olm.constraint
 
 The exact process for transitioning a cluster (fully) from OLMv0 to OLMv1 is not yet documented — this is an open question that affects all operators, not just Kuadrant. Currently on OpenShift OLMv1 and OLMv0 run alongside each other. However, regardless of when or how that transition happens, the dependency resolution mechanism Kuadrant relies on will not exist in the future. We should eliminate our dependency declarations now, while still on OLMv0, so that Kuadrant is already compatible when the transition arrives.
 
-### Dependency operators exist to satisfy OLM packaging requirements
+## Dependency operators exist to satisfy OLM packaging requirements
 
 These dependency operators (authorino-operator, limitador-operator) exist because OLMv0 required each component to be packaged as its own operator with its own CSV, Subscription, and CRD. They were created to satisfy this packaging requirement, not because the workloads they manage have complex lifecycle needs. Each maintains its own release pipeline, bundle images, and catalog entries. Consolidating them under the kuadrant-operator eliminates this per-component overhead.
 
-### Kuadrant needs to run beyond OpenShift
+## Kuadrant needs to run beyond OpenShift
 
 Kuadrant's deployment targets are not limited to OpenShift. In the future, we want to support any Kubernetes distribution (EKS, GKE, AKS, and others). An architecture that depends on OLM for installation and lifecycle management ties Kuadrant to an OpenShift-specific mechanism that doesn't exist on these platforms. Helm is the common denominator. Making Helm the primary installation method ensures Kuadrant is a first-class citizen on any Kubernetes distribution.
 
-### Reduced release and maintenance overhead
+## Reduced release and maintenance overhead
 
 Each independent OLM operator requires its own bundle image, catalog entry, release pipeline, and version coordination. Consolidating into a single OLM package eliminates per-component release overhead while keeping the same controllers and workloads running on the cluster. No CRDs, Deployments, or other resources are removed or deprecated as part of this work.
 
@@ -57,11 +57,11 @@ Each independent OLM operator requires its own bundle image, catalog entry, rele
 
 The kuadrant-operator becomes an umbrella operator that deploys component controllers at runtime. Wrapper CRs (Authorino CR, Limitador CR) are preserved. No breaking changes for users.
 
-### Before
+## Before
 
 4 OLM operators (kuadrant, authorino, limitador, dns), each with its own CSV, bundle image, and catalog entry. OLM manages all lifecycles independently.
 
-### After
+## After
 
 1 OLM operator (kuadrant-operator) with a single CSV, bundle, and catalog entry. Component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway) are no longer OLM packages. They become internal controller deployments whose lifecycle is managed by the kuadrant-operator. No component controller bundles, catalogs, or CSVs need to be maintained.
 
@@ -70,11 +70,11 @@ The kuadrant-operator becomes an umbrella operator that deploys component contro
 
 For visual diagrams covering the build-time chart sync, runtime reconciliation chain, RBAC model, and resource ownership, see [Architecture Diagrams](0019-olmv1-operator-consolidation/architecture-diagrams.md).
 
-### Chart sync process
+## Chart sync process
 
 Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A Go sync tool (`hack/sync-child-charts/`) downloads each chart, renders it using the Helm SDK, and classifies the rendered resources by kind. The output is split into three directories:
 
-```
+```text
 config/child-operators/
 ├── crds/                         # Rendered CRDs (one file per component)
 │   ├── authorino-operator.yaml
@@ -102,7 +102,11 @@ The sync tool handles both simple charts (single `manifests.yaml` generated by k
 
 Synced charts are committed to the repo. The sync is run manually via `make sync-child-operator-charts` when updating component versions.
 
-### Resource ownership
+## Kuadrant-operator Helm chart
+
+The kuadrant-operator's own Helm chart (`charts/kuadrant-operator/`) should be updated to follow Helm best practices. Currently, it's a monolithic `manifests.yaml` generated by kustomize with all resources (including CRDs) inline in `templates/`. As part of this work, the chart should be restructured to use Helm's native `crds/` directory for all CRDs (kuadrant and component). This ensures correct install ordering (CRDs installed before templates) and aligns with Helm conventions.
+
+## Resource ownership
 
 Resource ownership is clearly split between the installation method and the operator:
 
@@ -128,43 +132,47 @@ Resource ownership is clearly split between the installation method and the oper
 
 The operator does not create or modify cluster-scoped resources (CRDs, ClusterRoles) at runtime. If a rendered chart produces a ClusterRole or CRD, the operator skips it with a log warning.
 
-### Runtime rendering
+## Runtime rendering
 
 When a user creates a Kuadrant CR, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). The rendered namespaced resources are applied via Server-Side Apply with the kuadrant-operator as the field manager.
 
 All component controller Deployments are owned by the Kuadrant CR via ownerReference. This includes dns-operator, which previously ran independently and did not require a Kuadrant CR.
 
-### RBAC
+## RBAC
 
 The kuadrant-operator does not need to duplicate component controller permissions. The Kubernetes `bind` verb allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions. The operator's ClusterRole includes `bind`/`escalate` on each component's ClusterRole `resourceNames`.
 
+`bind` is sufficient for steady-state runtime operation (creating ClusterRoleBindings). `escalate` is retained for migration scenarios where the operator may need to update existing ClusterRole rules to align with the consolidated model. Whether rule changes are needed depends on the migration implementation. If migration only requires metadata updates (annotations, labels), `escalate` can be removed.
+
 Only ClusterRole names need tracking, not their contents. When a component controller changes its RBAC rules, no kuadrant-operator change is needed unless a ClusterRole is added or renamed.
 
-### Two supported installation methods
+Component ClusterRoles must use fixed, predictable names. The `bind`/`escalate` permissions use `resourceNames`, so the operator must know the exact names at build time. Charts that derive ClusterRole names from the Helm release name (e.g. via the `fullname` helper) create a fragile dependency that can silently break the RBAC contract. The sync tool validates rendered ClusterRole names at sync time, catching any mismatches before they reach a cluster.
 
-- **Helm**: Single `helm install` deploys everything. The kuadrant-operator Helm chart includes component CRDs and ClusterRoles in its templates (generated by `kustomize build` from `config/child-operators/crds/` and `config/child-operators/rbac/` at `make helm-build` time).
+## Two supported installation methods
+
+- **Helm**: Single `helm install` deploys everything. The kuadrant-operator Helm chart includes all CRDs (kuadrant and component) in its `crds/` directory following Helm best practices, and component ClusterRoles in `templates/`. CRDs and ClusterRoles are generated at `make helm-build` time from `config/child-operators/crds/` and `config/child-operators/rbac/` via kustomize.
 - **OLM**: Single operator in the catalog. The bundle includes all component CRDs and ClusterRoles (from `config/child-operators/` via `config/manifests/kustomization.yaml`). No component controller bundles in the catalog.
 
 Both paths produce the same cluster state: CRDs and ClusterRoles installed, kuadrant-operator running, no component controllers until a Kuadrant CR is created.
 
-### Wrapper CRs preserved
+## Wrapper CRs preserved
 
 Authorino CR and Limitador CR are still created by kuadrant-operator. Component controllers reconcile these wrapper CRs to create workloads. No change to this flow. Users see no difference in behaviour.
 
-### Kuadrant CR deletion must manage component lifecycle
+## Kuadrant CR deletion must manage component lifecycle
 
 Component controller Deployments are owned by the Kuadrant CR via ownerReference. Several CRDs use finalizers that require their controller to be running:
 
 - Authorino CR has finalizer `authorino.kuadrant.io/finalizer`
 - DNSRecord CRs have finalizers for cleaning up external DNS provider records
 
-If the Kuadrant CR is deleted and the cascade deletes the controllers simultaneously, CRs with finalizers will be stuck in `Terminating` state. The kuadrant-operator must have a finalizer on the Kuadrant CR that enforces correct deletion order: delete wrapper CRs and wait for finalizers to complete before allowing the cascade to remove component controller Deployments.
+If the Kuadrant CR is deleted and the cascade deletes the controllers simultaneously, CRs with finalizers will be stuck in `Terminating` state. The kuadrant-operator must have a finalizer on the Kuadrant CR that enforces correct deletion order: ensure all controller-dependent resources with finalizers (wrapper CRs, DNSRecords, and any others) have completed their finalizer logic before allowing the cascade to remove component controller Deployments.
 
-### OLM bundle and catalog
+## OLM bundle and catalog
 
 The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. Component CRDs and ClusterRoles are included in the kuadrant-operator bundle directly from `config/child-operators/`.
 
-### Component repos
+## Component repos
 
 No changes are required in component repos for the consolidation to work. The sync tool will be designed to handle any chart structure.
 
@@ -177,11 +185,11 @@ However, some upstream chart changes would be beneficial:
 
 Since component repos no longer need to produce their own OLM bundles or catalogs, OLM-specific artefacts can also be removed to reduce maintenance burden: `bundle/`, `catalog/`, `config/manifests/`, `config/deploy/olm/`, `config/scorecard/`, `bundle.Dockerfile`, `operator-sdk` and `opm` tool dependencies.
 
-### Automated dependency sync
+## Automated dependency sync
 
 Component repos need automation to notify the kuadrant-operator when their charts change. A pattern already exists between authorino and authorino-operator: push to main triggers a `repository_dispatch` to the downstream repo, which runs the sync tool and creates a PR.
 
-### Migration considerations
+## Migration considerations
 
 - **CRD ownership transfer**: OLM tracks CRD ownership via annotations. These need updating during the transition.
 - **Orphaned OLM resources**: OLM will not automatically uninstall previously resolved child operators. Subscriptions, CSVs, and associated resources must be explicitly cleaned up.
@@ -210,7 +218,7 @@ This RFC deliberately preserves wrapper CRs and child operator controllers. A fo
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-### Why this design
+## Why this design
 
 - **No new operator**: the kuadrant-operator itself becomes the umbrella operator, avoiding a new codebase, image, CI pipeline, and release process.
 - **No breaking changes**: wrapper CRs are preserved. Wrapper CR removal is deferred to a follow-on RFC when it can be properly investigated and tested.
@@ -218,7 +226,7 @@ This RFC deliberately preserves wrapper CRs and child operator controllers. A fo
 - **Reduced operator footprint**: the OLM catalog goes from 4 packages to 1. Component repos can remove all OLM-specific artefacts.
 - **Proven pattern**: OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) uses Helm client-only rendering in production.
 
-### Alternatives considered
+## Alternatives considered
 
 #### New umbrella operator (separate from kuadrant-operator)
 

--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -1,6 +1,6 @@
-# RFC: Evolving the Kuadrant Deployment
+# RFC: Kuadrant Operator Consolidation
 
-- Feature Name: `kuadrant_deployment_consolidation`
+- Feature Name: `kuadrant_operator_consolidation`
 - Start Date: 2026-06-11
 - RFC PR: [Kuadrant/architecture#0000](https://github.com/Kuadrant/architecture/pull/0000)
 - Issue tracking: [Kuadrant/architecture#164](https://github.com/Kuadrant/architecture/issues/164)
@@ -8,7 +8,24 @@
 # Summary
 [summary]: #summary
 
-Maintain a single-action install experience with OLMv1. Reduce Kuadrant's operator footprint, release complexity, security surface area, and maintenance burden by eliminating authorino-operator and limitador-operator as separate components in a Kuadrant deployment. Make Helm the primary installation and configuration mechanism for Kuadrant across OpenShift, *.KS (AKS, GKS) and general Kubernetes. Introduce an "umbrella operator" to coordinate installation via programmatic Helm installation.
+Consolidate the Kuadrant ecosystem into a single operator. The kuadrant-operator manages all component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway), removing the need for separate OLM packages per component. Users install one operator via Helm or OLM and get a fully functional Kuadrant deployment.
+
+# Goals
+
+1. Prepare for OLMv1 by removing OLM operator dependency declarations (`dependencies.yaml`). All changes are implemented and tested on OLMv0
+2. Deploy all component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway) from the kuadrant-operator at runtime
+3. Support two installation methods from a single operator: OLM (for OpenShift) and Helm (for any Kubernetes distribution). Maintain a valid Helm chart for kuadrant-operator as a first-class installation method
+4. Bring mcp-gateway into the Kuadrant ecosystem as a managed component controller
+5. Reduce the number of OLM packages from 4 to 1, simplifying the release and catalog pipeline
+6. Maintain a single-action install experience for users
+7. No deprecations: all existing CRDs, Deployments, and resources remain. The same controllers and workloads run on the cluster as before
+
+# Non-goals
+
+1. **Removing wrapper CRs (Authorino CR, Limitador CR)**: these are preserved. Deferred to a follow-on RFC
+2. **Removing child operator controllers**: authorino-operator and limitador-operator continue to run as Deployments. Deferred to a follow-on RFC
+3. **Migrating to OLMv1**: all changes run on OLMv0. OLMv1 compatibility is a readiness outcome, not a migration step
+4. **Refactoring component Helm charts**: upstream charts are consumed as-is. Improved templating is future work
 
 # Motivation
 [motivation]: #motivation
@@ -23,292 +40,237 @@ Bundles declaring `olm.package.required`, `olm.gvk.required`, or `olm.constraint
 
 The exact process for transitioning a cluster (fully) from OLMv0 to OLMv1 is not yet documented — this is an open question that affects all operators, not just Kuadrant. Currently on OpenShift OLMv1 and OLMv0 run alongside each other. However, regardless of when or how that transition happens, the dependency resolution mechanism Kuadrant relies on will not exist in the future. We should eliminate our dependency declarations now, while still on OLMv0, so that Kuadrant is already compatible when the transition arrives.
 
-### Most of our dependency operators are simple wrappers
+### Dependency operators exist to satisfy OLM packaging requirements
 
-Operators are also acknowledged as a relatively complex solution for simple deployments. The [OLMv1 design decisions](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md#authors-of-simple-operators-ship-their-workload-without-an-operator) document identifies workloads that don't benefit from the operator pattern:
-
-> A sizable portion of the OperatorHub catalog contain operators that are not actually taking advantage of the benefits of the operator pattern and are instead a simple wrapper around the workload. Using the Operator Capability Levels as a rubric, operators that fall into Level 1 and some that fall into Level 2 are not making full use of the operator pattern.
-> If content authors had the choice to ship their content without also shipping an operator that performs simple installation and upgrades, many supporting these Level 1 and Level 2 operators might make that choice to decrease their overall maintenance and support burden while losing very little in terms of value to their customers.
-
-These dependency operators exist because OLMv0 required each component to be packaged as its own operator with its own CSV, Subscription, and CRD. They were created to satisfy this packaging requirement, not because the workloads they manage have complex lifecycle needs. Some of our operators fall into this category:
-
-**authorino-operator**: The reconciler creates a ServiceAccount, Services, RBAC, and a Deployment. It maps `Authorino` CR fields to Deployment args and volumes. The only non-trivial logic is toggling between cluster-wide and namespaced RBAC. A Helm chart with conditionals provides identical functionality.
-
-**limitador-operator**: The reconciler creates a Service, Deployment, limits ConfigMap, optional PVC, and optional PodDisruptionBudget. The storage backend switch (in-memory, Redis, Redis-cached, disk) translates to different args, volumes, and deployment strategy. Still a spec-to-Deployment mapper replaceable by Helm.
-
-The `Limitador` CR has an additional overlap: it also declares rate limits in `spec.limits`. Today, kuadrant-operator writes limits into this field, limitador-operator serializes them into a ConfigMap, and Limitador reads the mounted config file. In Kuadrant, the kuadrant-operator via policy is the only producer of limits kuadrant-operator can write the ConfigMap directly.
+These dependency operators (authorino-operator, limitador-operator) exist because OLMv0 required each component to be packaged as its own operator with its own CSV, Subscription, and CRD. They were created to satisfy this packaging requirement, not because the workloads they manage have complex lifecycle needs. Each maintains its own release pipeline, bundle images, and catalog entries. Consolidating them under the kuadrant-operator eliminates this per-component overhead.
 
 ### Kuadrant needs to run beyond OpenShift
 
-Kuadrant's deployment target(s) are not limited to OpenShift. In the future, we want to support any Kubernetes distribution — EKS, GKE, AKS, and others. An architecture that depends on OLM for installation and lifecycle management ties Kuadrant to an OpenShift-specific mechanism that doesn't exist on these platforms. Helm is the common denominator. Making Helm the primary installation method ensures Kuadrant is a first-class citizen on any Kubernetes distribution, with the umbrella operator serving as an OpenShift-specific layer.
+Kuadrant's deployment targets are not limited to OpenShift. In the future, we want to support any Kubernetes distribution (EKS, GKE, AKS, and others). An architecture that depends on OLM for installation and lifecycle management ties Kuadrant to an OpenShift-specific mechanism that doesn't exist on these platforms. Helm is the common denominator. Making Helm the primary installation method ensures Kuadrant is a first-class citizen on any Kubernetes distribution.
 
-### Fewer operators means a smaller security surface area and maintenance overhead
+### Reduced release and maintenance overhead
 
-Each operator is a long-running privileged controller with its own ServiceAccount and cluster-scoped RBAC. authorino-operator holds permissions to create and modify ClusterRoles, ClusterRoleBindings, Deployments, Services, and Secrets across namespaces.
-
-Each operator is also a separate container image with its own Go dependency tree. Every transitive dependency is a potential CVE that needs scanning, patching, and releasing. Eliminating two operators removes two privileged controllers from the cluster and two dependency trees from the security maintenance pipeline.
+Each independent OLM operator requires its own bundle image, catalog entry, release pipeline, and version coordination. Consolidating into a single OLM package eliminates per-component release overhead while keeping the same controllers and workloads running on the cluster. No CRDs, Deployments, or other resources are removed or deprecated as part of this work.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-### Install on upstream Kubernetes
+The kuadrant-operator becomes an umbrella operator that deploys component controllers at runtime. Wrapper CRs (Authorino CR, Limitador CR) are preserved. No breaking changes for users.
 
-Users install Kuadrant directly via Helm:
+### Before
 
-```bash
-helm install kuadrant kuadrant/kuadrant
-```
+4 OLM operators (kuadrant, authorino, limitador, dns), each with its own CSV, bundle image, and catalog entry. OLM manages all lifecycles independently.
 
-The chart deploys all components — kuadrant-operator, Authorino, Limitador, and dns-operator — with configurable values for image references, replicas, resource limits, storage backend, and TLS.
+### After
 
-### Install on OpenShift (OLM)
-
-Users create a single Subscription (OLMv0) or ClusterExtension (OLMv1) for the umbrella operator. This is the only OLM resource the user creates. The umbrella operator renders the same Helm charts internally and deploys all components.
-
-### Kuadrant CR
-
-Users create a Kuadrant CR to configure operand behaviour — mTLS, observability, tracing, and developer portal. The umbrella operator now owns and reconciles this CR. kuadrant-operator watches only policy CRs (AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, TokenRateLimitPolicy).
-
-### Breaking changes
-
-The `Authorino` and `Limitador` CRDs are part of Kuadrant's internal API surface — they are not user-facing. The public API (Kuadrant CR, AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, TokenRateLimitPolicy) is unchanged.
-
-- **`Authorino` CRD dropped** — internal deployment configuration moves to Helm values.
-- **`Limitador` CRD dropped** — internal deployment configuration moves to Helm values. Rate limits written directly to ConfigMap by kuadrant-operator.
+1 OLM operator (kuadrant-operator) with a single CSV, bundle, and catalog entry. Component controllers (authorino-operator, limitador-operator, dns-operator, mcp-gateway) are no longer OLM packages. They become internal controller deployments whose lifecycle is managed by the kuadrant-operator. No component controller bundles, catalogs, or CSVs need to be maintained.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-### Umbrella Operator
+For visual diagrams covering the build-time chart sync, runtime reconciliation chain, RBAC model, and resource ownership, see [Architecture Diagrams](0019-olmv1-operator-consolidation/architecture-diagrams.md).
 
-A single operator published as an OLMv0 package with zero dependency declarations. It manages all Kuadrant components internally by rendering Helm charts at runtime using Helm's Go SDK with `ClientOnly=true` and `DryRun=true` — pure template rendering with no Helm release tracking. Rendered manifests are applied via controller-runtime. Charts are embedded in the umbrella operator image at build time.
+### Chart sync process
 
-The umbrella operator owns the component Deployments — not OLM. authorino-operator and limitador-operator are eliminated and their workloads are deployed directly. The umbrella operator provides a place to coordinate migration logic for cleaning up these operators on existing clusters.
+Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A Go sync tool (`hack/sync-child-charts/`) downloads each chart, renders it using the Helm SDK, and classifies the rendered resources by kind. The output is split into three directories:
 
-On OLMv0, the umbrella operator is installed via a standard Subscription. If/when the cluster transitions to OLMv1, it migrates as a single ClusterExtension with no dependencies.
+```
+config/child-operators/
+├── crds/                         # Rendered CRDs (one file per component)
+│   ├── authorino-operator.yaml
+│   ├── limitador-operator.yaml
+│   ├── dns-operator.yaml
+│   └── mcp-gateway.yaml
+├── rbac/                         # Rendered ClusterRoles (one file per component)
+│   ├── authorino-operator.yaml
+│   ├── limitador-operator.yaml
+│   ├── dns-operator.yaml
+│   └── mcp-gateway.yaml
+└── charts/                       # Raw chart templates for runtime rendering
+    ├── authorino-operator/
+    ├── limitador-operator/
+    ├── dns-operator/
+    └── mcp-gateway/
+```
 
-This follows the pattern used by OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator).
+The separation serves a specific purpose:
 
-### Helm Chart Refactoring
+- **`crds/` and `rbac/`** contain rendered output (real resource names, no Helm template expressions). These are included in the kuadrant-operator's OLM bundle and Helm chart via kustomize at build time. They are cluster-scoped resources managed by the installation method.
+- **`charts/`** contains the raw Helm chart templates (Chart.yaml, values.yaml, templates/) copied as-is from upstream. These are packaged into the operator container image and rendered at runtime when a Kuadrant CR is created.
 
-The current kuadrant-operator chart (`charts/kuadrant-operator/`) is a monolithic kustomize-generated blob — a single `manifests.yaml` of ~14,500 lines produced by `kustomize build config/helm`. This must be refactored to support per-component rendering, ordered deployment, and direct workload deployment.
+The sync tool handles both simple charts (single `manifests.yaml` generated by kustomize) and mature charts with full Helm templating (helpers, conditionals, configurable values). It renders to classify resources but preserves the raw templates for runtime use.
 
-**Required changes:**
+Synced charts are committed to the repo. The sync is run manually via `make sync-child-operator-charts` when updating component versions.
 
-1. **Replace kustomize generation with per-component Helm templates** — one template per component (Deployment, Service, RBAC, ServiceAccount). CRDs must be separated (via Helm's `crds/` directory or a dedicated template) since they must be established before resources that depend on them.
-2. **Configurable values.yaml** — image references, namespaces, replica counts, and resource limits exposed as values. The umbrella operator injects version-pinned values at render time; direct Helm users override via `--set` or values files.
-3. **Workload templates for Authorino and Limitador** — the chart deploys these workloads directly (Deployment, Service, RBAC) rather than creating operator CRs. Configuration previously exposed via the `Authorino` and `Limitador` CRs moves to Helm values.
-4. **Ordered rendering support** — the umbrella operator renders and applies charts sequentially: CRDs first, then workloads and dependencies, then kuadrant-operator.
+### Resource ownership
 
-> The exact layout and requirements for these charts is something to be investigated and beyond the details of this doc.
+Resource ownership is clearly split between the installation method and the operator:
 
-### Managed Resources
+**Managed by the installer (Helm chart or OLM bundle):**
 
-Resource ownership is split between OLM and the umbrella operator.
-
-**Managed by OLM (via the umbrella operator's bundle/CSV):**
-
-| Resource | Purpose |
-|---|---|
-| CustomResourceDefinitions | All Kuadrant and DNS CRDs. Authorino and Limitador CRDs are dropped. OLM handles install, upgrade, and CRD safety checks. |
-| ClusterRoles / ClusterRoleBindings | RBAC for the umbrella operator and kuadrant-operator. |
-| Umbrella operator Deployment | The umbrella operator itself. |
-
-**Managed by the umbrella operator (rendered from Helm charts):**
-
-| Resource | Purpose |
-|---|---|
-| Deployments | kuadrant-operator, dns-operator, Authorino (workload), Limitador (workload) |
-| ServiceAccounts | Per-component service identity |
-| Roles / RoleBindings | Namespace-scoped RBAC  |
-| Services | Metrics, auth, OIDC, rate limiting |
-| ConfigMaps | Limitador limits (written by kuadrant-operator), operator configuration |
-
-**Not managed by the umbrella operator or OLM:**
-
-| Resource | Owner |
-|---|---|
-| Policy CRs (AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, etc.) | User-created, reconciled by kuadrant-operator |
-| AuthConfig CRs | Created by kuadrant-operator, reconciled by Authorino |
-
-### Kuadrant CR Ownership
-
-The Kuadrant CR moves from kuadrant-operator to the umbrella operator. Analysis of the [Kuadrant CR spec](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/reference/kuadrant.md) shows that its fields are concerned with operand management, operand configuration, and infrastructure wiring — not policy reconciliation.
-
-| Spec field | Action | Category |
+| Resource | Source | Notes |
 |---|---|---|
-| (existence of CR) | Previously created Authorino and Limitador operand CRs — now triggers Helm-rendered workload configuration | Operand management |
-| `spec.mtls.*` | Configures PeerAuthentication for mTLS between gateway and operands | Operand configuration |
-| `spec.observability.enable` | Creates ServiceMonitor and PodMonitor CRs | Infrastructure wiring |
-| `spec.observability.tracing.*` | Sets tracing endpoint on Authorino and Limitador | Operand configuration |
-| `spec.observability.dataPlane.*` | Drives wasm-shim configuration via effective policy computation | Data plane configuration |
-| `spec.components.developerPortal.enabled` | Creates/deletes Developer Portal Deployment | Operand management |
+| All CRDs (kuadrant + component) | `config/child-operators/crds/` and `config/crd/` | Installed before the operator starts |
+| Component ClusterRoles | `config/child-operators/rbac/` | Installed before the operator starts |
+| kuadrant-operator Deployment | `config/manager/` | The operator itself |
+| kuadrant-operator ServiceAccount, ClusterRole, ClusterRoleBinding | `config/rbac/` | Operator's own RBAC |
 
-kuadrant-operator stops watching the Kuadrant CR entirely — it only watches policy CRs.
+**Managed by the kuadrant-operator at runtime (triggered by Kuadrant CR creation):**
 
-**Data plane observability configuration:** The one field that crosses the boundary is `spec.observability.dataPlane`. The umbrella operator projects this configuration to kuadrant-operator via a ConfigMap or environment variables on the kuadrant-operator Deployment. The user-facing API remains unchanged. 
-
-### Migration (from existing OLMv0 installs)
-
-> Note this is an outline only and it needs more thorough investigation and testing to validate
-
-The umbrella operator is introduced **while the cluster is still running OLMv0**. On startup, it takes over deployment of all Kuadrant components. The migration sequence ensures zero data plane disruption.
-
-#### Migration flow
-
-1. **Scale down authorino-operator to 0 replicas** — stops reconciling. Authorino pods continue running. Data plane unaffected.
-2. **Strip ownerReferences** from Authorino Deployment, Services, and RBAC pointing to the `Authorino` CR.
-3. **Apply Helm-rendered Authorino resources** (same names) — takes ownership. No pod restart — same Deployment spec.
-4. **Strip finalizer from `Authorino` CR, then delete it** — no cascading deletion since ownerReferences were removed.
-5. **Repeat for limitador-operator** — scale down, strip ownerReferences from Limitador Deployment/Service/ConfigMap/PVC/PDB, apply Helm resources, strip finalizer, delete `Limitador` CR.
-6. **Deploy updated kuadrant-operator from Helm** — this version writes limits ConfigMap directly and drops its watch on the Kuadrant CR.
-7. **Umbrella operator takes ownership of the Kuadrant CR** — begins reconciling operand configuration, mTLS, observability.
-8. **Clean up OLMv0 Subscriptions and CSVs** for the dependency operators — CSV deletion cascades to the operator Deployments (authorino-operator, limitador-operator), removing them. The operators are already scaled to 0 at this point so there is no impact. Helm-rendered workload resources are unaffected as they are owned by the umbrella operator, not the CSVs.
-
-Each step is idempotent — if the umbrella operator restarts mid-migration, it re-checks state and resumes.
-
-> Note: the first version of the umbrella operator will contain migration-specific logic that can be removed in subsequent versions.
-
-#### What survives the migration
-
-| Resource | Behaviour |
+| Resource | Notes |
 |---|---|
-| CRDs | Persist — OLMv0 never deletes CRDs |
-| Operand processes (Authorino, Limitador) | Continue running — pods are never deleted during migration |
-| User-created CRs (policies, Kuadrant CR) | Persist |
-| AuthConfig CRs | Persist — Authorino continues reconciling them |
-| Data plane (auth, rate limiting) | No disruption — operands keep serving traffic |
+| Component controller Deployments | authorino-operator, limitador-operator, dns-operator, mcp-gateway |
+| Component ServiceAccounts | Per-component identity |
+| Component ClusterRoleBindings | Binds component SAs to pre-installed ClusterRoles using `bind`/`escalate` |
+| Component Roles, RoleBindings | Namespace-scoped RBAC (e.g. leader election) |
+| Component Services, ConfigMaps | Metrics, configuration |
+| Wrapper CRs | Authorino CR, Limitador CR (reconciled by child operators into workloads) |
 
-#### Control plane gap
+The operator does not create or modify cluster-scoped resources (CRDs, ClusterRoles) at runtime. If a rendered chart produces a ClusterRole or CRD, the operator skips it with a log warning.
 
-There is a brief window per component (between operator scale-down and Helm Deployment apply) where no controller is watching that component's configuration. During this window:
+### Runtime rendering
 
-- Existing policies continue to be enforced by the running operands
-- New policy changes or CR updates are not reconciled until the replacement is in place
-- No user action is required — the umbrella operator handles the entire sequence
+When a user creates a Kuadrant CR, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). The rendered namespaced resources are applied via Server-Side Apply with the kuadrant-operator as the field manager.
 
-### Steady-state Upgrades
+All component controller Deployments are owned by the Kuadrant CR via ownerReference. This includes dns-operator, which previously ran independently and did not require a Kuadrant CR.
 
-OLM deploys the new umbrella operator image (containing updated charts and image references); the umbrella operator handles everything else.
+### RBAC
 
-1. OLM upgrades the umbrella operator bundle — this updates CRDs, ClusterRoles, and ClusterRoleBindings.
-2. The umbrella operator re-renders charts, detects drift, and applies changes in order:
-   - **Workloads** (Authorino, Limitador) and **dns-operator** — updated first, waited on until healthy.
-   - **kuadrant-operator** last — as the policy reconciler, it may depend on new capabilities from the updated workloads.
+The kuadrant-operator does not need to duplicate component controller permissions. The Kubernetes `bind` verb allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions. The operator's ClusterRole includes `bind`/`escalate` on each component's ClusterRole `resourceNames`.
 
-### Version Pinning
+Only ClusterRole names need tracking, not their contents. When a component controller changes its RBAC rules, no kuadrant-operator change is needed unless a ClusterRole is added or renamed.
 
-Each umbrella operator release pins component versions via Helm values embedded at build time. Image references for all components are set through the charts' `values.yaml`, ensuring a single mechanism for version control across both install paths.
+### Two supported installation methods
 
-### Extension Operators
+- **Helm**: Single `helm install` deploys everything. The kuadrant-operator Helm chart includes component CRDs and ClusterRoles in its templates (generated by `kustomize build` from `config/child-operators/crds/` and `config/child-operators/rbac/` at `make helm-build` time).
+- **OLM**: Single operator in the catalog. The bundle includes all component CRDs and ClusterRoles (from `config/child-operators/` via `config/manifests/kustomization.yaml`). No component controller bundles in the catalog.
 
-Extension operators (e.g., mcp-gateway-operator) complement kuadrant-operator rather than being consumed by it. They are **not managed by the umbrella operator in the initial implementation**.
+Both paths produce the same cluster state: CRDs and ClusterRoles installed, kuadrant-operator running, no component controllers until a Kuadrant CR is created.
 
-Extension operators must independently remove their OLMv0 dependency declarations. The umbrella operator's architecture supports absorbing them as subcharts in a future iteration.
+### Wrapper CRs preserved
 
-### Upgrade Testing
+Authorino CR and Limitador CR are still created by kuadrant-operator. Component controllers reconcile these wrapper CRs to create workloads. No change to this flow. Users see no difference in behaviour.
 
-The full upgrade lifecycle must be validated end-to-end.
+### Kuadrant CR deletion must manage component lifecycle
 
-**Test environment:** OpenShift with OLMv0, Kuadrant installed via OLMv0 Subscriptions, a Gateway with HTTPRoute/AuthPolicy/RateLimitPolicy applied, and active ingress traffic.
+Component controller Deployments are owned by the Kuadrant CR via ownerReference. Several CRDs use finalizers that require their controller to be running:
 
-A background process sends requests through the gateway continuously across all phases, recording success/failure rates.
+- Authorino CR has finalizer `authorino.kuadrant.io/finalizer`
+- DNSRecord CRs have finalizers for cleaning up external DNS provider records
 
-| Phase | Action | Validation |
-|---|---|---|
-| 1. Baseline | Record OLMv0 state (Subscriptions, CSVs, CRDs, pods) | All operators running, policies enforced |
-| 2. Migration | Install umbrella operator; wait for migration to complete | Only umbrella operator Subscription/CSV remains; all components running via Helm; data plane uninterrupted |
-| 3. Steady-state upgrade | Publish new umbrella operator version; OLM upgrades | All Deployments updated; no CRD regressions; data plane uninterrupted |
+If the Kuadrant CR is deleted and the cascade deletes the controllers simultaneously, CRs with finalizers will be stuck in `Terminating` state. The kuadrant-operator must have a finalizer on the Kuadrant CR that enforces correct deletion order: delete wrapper CRs and wait for finalizers to complete before allowing the cascade to remove component controller Deployments.
 
-### Failure Scenarios
+### OLM bundle and catalog
 
-- **Deployment rollout failure** — umbrella operator reports degraded status and blocks further upgrades.
-- **Image pull failure** — surfaced via Deployment's ImagePullBackOff condition.
-- **CRD conflict** — CRDs are in the OLM bundle. If a CRD already exists (e.g., standalone Authorino), OLM surfaces the conflict via status.
-- **Migration interrupted** — idempotent steps resume on restart.
+The bundle/catalog pipeline deals with a single package (kuadrant-operator). Component controller bundle images, catalog channel entries, and dependency injection are removed. Component CRDs and ClusterRoles are included in the kuadrant-operator bundle directly from `config/child-operators/`.
 
-### Day 2 Considerations
+### Component repos
 
-The dependency operators currently handle day 2 operations that must have a home in the new architecture.
+No changes are required in component repos for the consolidation to work. The sync tool will be designed to handle any chart structure.
 
-**PodDisruptionBudgets:** limitador-operator optionally creates a PDB for Limitador when `spec.pdb` is set (not created by default). authorino-operator does not manage a PDB. In the new architecture, users create PDBs directly if needed — no operator involvement required.
+However, some upstream chart changes would be beneficial:
 
-**Scaling replicas:** Both operators support configuring replicas via their CRs. In the new architecture, initial replica counts are set via Helm values at install time. Users can scale workloads directly via `kubectl scale` — since the umbrella operator owns the Deployments (not OLM), user-applied scaling is not reverted. The umbrella operator must respect user-set replica counts and not overwrite them on reconciliation.
+- **CRDs directory**: charts that keep CRDs in `templates/` rather than the native Helm `crds/` directory could benefit from separating them, making the sync tool's job cleaner
+- **Consistent labels**: applying consistent labels across all component resources (e.g. `kuadrant.io/component`) would improve topology tracking and filtering. Currently, the Authorino Deployment lacks distinguishing labels, preventing it from being tracked in the kuadrant-operator topology
+- **Unique Deployment selectors**: the limitador-operator chart uses a generic `control-plane: controller-manager` selector that collides with the kuadrant-operator in the same namespace. This is a pre-existing bug that needs fixing upstream
+- **Fixed ClusterRole names**: charts using Helm's `fullname` helper for ClusterRole names create a fragile dependency on the release name. ClusterRoles are cluster-scoped permission definitions and should use fixed names
 
-**Resource requirements:** Helm charts set sensible defaults for resource requests/limits. Users can adjust them directly on the Deployments. As with replicas, the umbrella operator must not overwrite user-applied resource configuration on reconciliation.
+Since component repos no longer need to produce their own OLM bundles or catalogs, OLM-specific artefacts can also be removed to reduce maintenance burden: `bundle/`, `catalog/`, `config/manifests/`, `config/deploy/olm/`, `config/scorecard/`, `bundle.Dockerfile`, `operator-sdk` and `opm` tool dependencies.
 
-**Storage backend changes:** limitador-operator supports switching between in-memory, Redis, Redis-cached, and disk at runtime via CR updates. In the new architecture, storage backend is configured via Helm values. Changing it requires a Helm upgrade or a Kuadrant CR update that triggers the umbrella operator to re-render. The deployment strategy implications (e.g., `Recreate` for disk storage) must be handled in the chart templates.
+### Automated dependency sync
 
-**TLS certificate management:** authorino-operator validates that TLS cert Secrets exist before proceeding with deployment. This preflight check must move to the Helm chart (e.g., via `required` in templates) or to the umbrella operator's reconciliation logic.
+Component repos need automation to notify the kuadrant-operator when their charts change. A pattern already exists between authorino and authorino-operator: push to main triggers a `repository_dispatch` to the downstream repo, which runs the sync tool and creates a PR.
 
-### Migration Risks
+### Migration considerations
 
-- **Finalizer stuck on `Authorino` or `Limitador` CR** — the dependency operators set finalizers on their CRs. During migration, the operator is scaled to 0 and cannot run its finalizer logic. If the umbrella operator fails to strip the finalizer (RBAC issue, API error), the CR hangs in `Terminating` state indefinitely, blocking migration progress. **Mitigation:** user manually removes the finalizer via `kubectl edit` or `kubectl patch`.
+- **CRD ownership transfer**: OLM tracks CRD ownership via annotations. These need updating during the transition.
+- **Orphaned OLM resources**: OLM will not automatically uninstall previously resolved child operators. Subscriptions, CSVs, and associated resources must be explicitly cleaned up.
+- **Control plane resource conflicts**: existing Deployments may have different field managers (OLM vs SSA). The safest approach is to delete old control plane resources before upgrade. This does not affect the data plane.
+- **Data plane continuity**: wrapper CRs must be preserved throughout migration. Their workloads continue running uninterrupted.
+- **Resource naming consistency**: resource names produced by the chart rendering should match names currently used by OLM-installed operators to avoid orphaned resources.
+- **Consistent labelling**: the umbrella operator can apply consistent labels to all managed resources, addressing existing gaps (e.g. Authorino Deployment lacks distinguishing labels for topology tracking).
 
-- **CSV deletion cascades to owned resources** — deleting a dependency operator's CSV on OLMv0 causes OLM to delete the resources that CSV owns (operator Deployment, RBAC, ServiceAccount). The migration flow defers CSV cleanup to the final step (step 8), after Helm-rendered workload resources are already in place and owned by the umbrella operator. The CSV cascade only affects the operator Deployments (authorino-operator, limitador-operator), which are already scaled to 0. However, if the migration steps are executed out of order — for example, if a CSV is deleted before ownerReferences are stripped and Helm resources applied — the cascade could remove resources that the workloads depend on. **Mitigation:** the umbrella operator must verify Helm-rendered resources are in place and owned before triggering CSV cleanup.
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+This RFC deliberately preserves wrapper CRs and child operator controllers. A follow-on RFC should address further architectural simplification:
+
+- **Removing intermediate operator layers and wrapper CRs**: deploying Authorino and Limitador workloads directly from the kuadrant-operator, eliminating authorino-operator and limitador-operator as running controllers. This removes the `Authorino` and `Limitador` CRDs from the user-facing API surface. Each operator removed is a separate container image with its own Go dependency tree. Every transitive dependency is a potential CVE that needs scanning, patching, and releasing. Removing these controllers reduces the security surface area and maintenance burden.
+- **Extracting a dedicated policy controller**: separating policy reconciliation (AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy) from the kuadrant-operator into a `kuadrant-policy-controller` deployed as a component, making the kuadrant-operator purely an orchestration layer.
+- **Selective component installation**: adding `spec.components` to the Kuadrant CRD for user-facing control over which components are deployed.
+- **Kuadrant CR evolution**: exposing day 2 configuration (replicas, resources, storage backend) through the Kuadrant CR.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- **New operator to build and maintain** — the umbrella operator introduces a new codebase, image, CI pipeline, and release process but in doing so removes two other operators
-- **Broad RBAC** — the umbrella operator needs permissions to manage Deployments, Services, RBAC, and ConfigMaps across namespaces.
-- **Two operators to debug** — users must distinguish umbrella operator issues (deployment) from kuadrant-operator issues (policy reconciliation).
+- **Broader RBAC for kuadrant-operator**: the kuadrant-operator now needs permissions to manage Deployments, Services, RBAC, and ConfigMaps for all component controllers, plus `bind`/`escalate` on their ClusterRoles.
+- **Chart sync maintenance**: component controller charts must be kept in sync. Automated dependency sync (via GitHub dispatch) mitigates this but adds CI complexity.
+- **Finalizer ordering**: the Kuadrant CR must manage deletion order to prevent wrapper CR finalizers from being orphaned. This adds reconciliation complexity.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 ### Why this design
 
-- **Separation of concerns** — kuadrant-operator is simplified to pure policy reconciliation; deployment orchestration is cleanly separated into the umbrella operator.
-- **Helm as first-class citizen** — both installation paths (direct Helm and umbrella operator) consume the same charts, unifying upstream and downstream experiences and preparing for a *.KS future.
-- **Reduced operator footprint** — eliminating two operators reduces security surface area, maintenance burden, and release complexity.
-- **Migration automation** — the umbrella operator can coordinate the transition from existing OLMv0 installs without manual intervention.
-- **Proven pattern** — OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) uses Helm client-only rendering at scale in production.
+- **No new operator**: the kuadrant-operator itself becomes the umbrella operator, avoiding a new codebase, image, CI pipeline, and release process.
+- **No breaking changes**: wrapper CRs are preserved. Wrapper CR removal is deferred to a follow-on RFC when it can be properly investigated and tested.
+- **Helm as first-class citizen**: both installation paths (direct Helm and OLM) consume the same charts, unifying upstream and downstream experiences.
+- **Reduced operator footprint**: the OLM catalog goes from 4 packages to 1. Component repos can remove all OLM-specific artefacts.
+- **Proven pattern**: OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) uses Helm client-only rendering in production.
 
 ### Alternatives considered
 
-#### Large CSV
+#### New umbrella operator (separate from kuadrant-operator)
 
-A single OLM bundle containing all existing operators in one CSV with zero dependency declarations. OLM owns the operator Deployments; the operators continue to manage operand Deployments via their CRs.
+A separate operator that coordinates deployment while kuadrant-operator handles only policy reconciliation.
 
 **Rejected because:**
-- Dependency operators are retained — their maintenance cost, security surface area, and release complexity remain. Does not advance the architectural simplification.
-- Migration for existing clusters is problematic — the OLMv1 design decisions doc states "if OLMv0 installs a dependency for you, it does not uninstall it when it is no longer depended upon." If correct (assumption — needs verification), upgrading to the big CSV would leave existing dependency Subscriptions/CSVs in place, resulting in duplicate operators. Manual cleanup would likely be required.
-- OLM owns all Deployments in the CSV and reconciles them back to the declared state — users cannot scale replicas, adjust resources, or change workload configuration without rebuilding the bundle.
-- All-or-nothing deployment — no path to selective deployment.
+- Introduces a new codebase, image, CI pipeline, and release process.
+- Two operators to debug (deployment issues vs policy issues).
+- The kuadrant-operator already has the Kuadrant CR watch, the topology, and the workflow infrastructure. Adding Helm rendering to it is simpler than building a new operator that needs all the same context.
+
+#### New umbrella operator with kuadrant-operator as policy controller
+
+Introduce a new umbrella operator for deployment orchestration. The existing kuadrant-operator becomes a pure policy controller deployed as a component, and the new operator takes ownership of the Kuadrant CR.
+
+**Rejected because:**
+- Introduces a new codebase, image, CI pipeline, and release process.
+- The kuadrant-operator already has the Kuadrant CR watch, the topology, and the workflow infrastructure. Adding Helm rendering to it is simpler than building a new operator that needs all the same context.
+- Two operators to debug (deployment issues vs policy issues).
+- Splitting policy reconciliation out of the kuadrant-operator can still be done as a future phase if needed, without requiring a new operator to be built first.
+
+#### Large CSV
+
+A single OLM bundle containing all existing operators in one CSV with zero dependency declarations.
+
+**Rejected because:**
+- Dependency operators are retained. Their maintenance cost, security surface area, and release complexity remain.
+- OLM owns all Deployments in the CSV and reconciles them back to the declared state. Users cannot scale replicas or adjust resources without rebuilding the bundle.
 - Does not put Helm at the centre of installation.
 
-#### Manual Installation of Dependencies
+#### Manual installation of dependencies
 
 Each component published as its own independent OLM package with no dependency declarations. Users install each one separately.
 
 **Rejected because:**
-- Significant UX regression — users must create multiple Subscriptions or ClusterExtensions, each with its own configuration.
+- Significant UX regression. Users must create multiple Subscriptions or ClusterExtensions.
 - Users are responsible for version compatibility and coordinated upgrades.
-- Does not scale — adding new components means more manual steps.
-- Same migration problem — users must manage the transition from dependency-based installation themselves.
+- Does not scale. Adding new components means more manual steps.
 
 # Prior art
 [prior-art]: #prior-art
 
-- **[cluster-olm-operator](https://github.com/openshift/cluster-olm-operator)** — primary reference. Manages OLMv1 sub-components using Helm charts rendered client-only, with static resource controllers and deployment controllers for applying the rendered manifests.
-- **[OLMv0 dependency resolution](https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/)** — the current model being replaced. Resolves dependencies automatically via CRD-based declarations.
-- **[OLMv1 design decisions](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md)** — documents why dependency resolution was removed and endorses simpler packaging for Level 1/2 operators.
+- **[cluster-olm-operator](https://github.com/openshift/cluster-olm-operator)**: manages OLMv1 sub-components using Helm charts rendered client-only.
+- **[OLMv0 dependency resolution](https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/)**: the current model being replaced.
+- **[OLMv1 design decisions](https://github.com/operator-framework/operator-controller/blob/main/docs/project/olmv1_design_decisions.md)**: documents why dependency resolution was removed.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- **OLMv0 → OLMv1 cluster transition** — the exact process for migrating a cluster from OLMv0 to OLMv1 is not documented. This affects all operators, not just Kuadrant. The umbrella operator approach ensures Kuadrant is ready regardless of how this transition works — zero dependency declarations, single Subscription/ClusterExtension.
+- **OLMv0 to OLMv1 cluster transition**: the exact process for migrating a cluster from OLMv0 to OLMv1 is not documented. The umbrella operator approach ensures Kuadrant is ready regardless of how this transition works.
 
-- **OLMv0 behaviour when a CSV drops dependency declarations** — when the kuadrant-operator CSV is upgraded to a version that removes its `olm.package.required` declarations, what happens to the dependency Subscriptions/CSVs that OLMv0 auto-installed? The OLMv1 design doc states they are not automatically removed, but this needs verification.
+- **OLMv0 behaviour when a CSV drops dependency declarations**: when the kuadrant-operator CSV is upgraded to a version that removes its `olm.package.required` declarations, what happens to the dependency Subscriptions/CSVs that OLMv0 auto-installed? The OLMv1 design doc states they are not automatically removed, but this needs verification.
 
-- **CRD ownership conflicts with standalone installations** — if standalone Authorino is already installed on a cluster, the umbrella operator's bundle includes Authorino CRDs. Under OLMv1's single-ownership model, two bundles cannot own the same CRDs.
+- **CRD ownership conflicts with standalone installations**: if standalone Authorino is already installed on a cluster, the kuadrant-operator's bundle includes Authorino CRDs. Under OLMv1's single-ownership model, two bundles cannot own the same CRDs.
 
-# Future possibilities
-[future-possibilities]: #future-possibilities
-
-- **Selective component deployment** — the umbrella operator can conditionally render only the charts for components the user needs. Extension operators like mcp-gateway-operator would be natural candidates for opt-in deployment. Safety checks could prevent removing components with active policy CRs.
-
-- **Absorbing extension operators** — mcp-gateway-operator and future extensions can be folded into the umbrella operator as subcharts, extending the single-action install to cover the full Kuadrant ecosystem.
-
-- **Kuadrant CR evolution** — with the umbrella operator owning operand configuration, the Kuadrant CR could evolve to expose selective deployment toggles (e.g., `spec.components.rateLimiting.enabled`) without requiring kuadrant-operator changes.
+- **Wrapper CR removal timeline**: this RFC preserves wrapper CRs. The timeline and approach for removing them depends on how much the Authorino and Limitador CRs are used for direct user customisation vs being purely internal. This will be addressed in a follow-on RFC.

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -4,11 +4,12 @@
 
 | Term | Meaning |
 |------|---------|
-| **SSA** | Server-Side Apply — Kubernetes apply method where the server tracks field ownership per manager |
+| **SSA** | Server-Side Apply, the Kubernetes apply method where the server tracks field ownership per manager |
 | **CRB** | ClusterRoleBinding |
 | **SA** | ServiceAccount |
 | **CRD** | CustomResourceDefinition |
-| **bind** | RBAC verb that allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions |
+| **escalate** | RBAC verb that allows creating ClusterRoles with permissions the creator does not hold |
+| **bind** | RBAC verb that allows creating ClusterRoleBindings to ClusterRoles whose permissions the creator does not hold |
 | **GITREF** | Git reference (branch, tag, or SHA) used to pull charts from upstream repos |
 | **Wrapper CR** | Authorino/Limitador custom resources created by kuadrant-operator and reconciled by child operators |
 
@@ -23,63 +24,49 @@ graph LR
         MG["Kuadrant/mcp-gateway"]
     end
 
-    SYNC["make sync-child-operator-charts<br/>Go tool: hack/sync-child-charts/"]
+    SYNC["make sync-child-operator-charts"]
 
     AO -->|GITREF| SYNC
     LO -->|GITREF| SYNC
     DO -->|GITREF| SYNC
     MG -->|GITREF| SYNC
 
-    subgraph local["config/child-operators/"]
-        subgraph crds["crds/"]
-            ao_c["authorino-operator.yaml"]
-            lo_c["limitador-operator.yaml"]
-            do_c["dns-operator.yaml"]
-            mg_c["mcp-gateway.yaml"]
-        end
-        subgraph rbac["rbac/"]
-            ao_r["authorino-operator.yaml"]
-            lo_r["limitador-operator.yaml"]
-            do_r["dns-operator.yaml"]
-            mg_r["mcp-gateway.yaml"]
-        end
-        subgraph charts["charts/"]
-            ao_t["authorino-operator/"]
-            lo_t["limitador-operator/"]
-            do_t["dns-operator/"]
-            mg_t["mcp-gateway/"]
-        end
+    subgraph local["config/child-operators/charts/"]
+        ao_t["authorino-operator/"]
+        lo_t["limitador-operator/"]
+        do_t["dns-operator/"]
+        mg_t["mcp-gateway/"]
     end
 
-    SYNC --> crds
-    SYNC --> rbac
-    SYNC --> charts
+    SYNC -->|"copies chart as-is"| local
 ```
+
+Charts are copied unmodified from upstream repos. No rendering, splitting, or classification at sync time. Each chart directory contains the complete upstream chart (Chart.yaml, values.yaml, templates/, crds/).
 
 ```mermaid
 graph LR
-    subgraph local["config/child-operators/"]
-        CRDs["crds/"]
-        RBAC["rbac/"]
-        CHARTS["charts/"]
+    subgraph local["config/child-operators/charts/"]
+        CHARTS["Complete upstream charts"]
     end
 
-    CRDs -->|"make bundle"| BUNDLE["OLM Bundle"]
-    RBAC -->|"make bundle"| BUNDLE
-    CRDs -->|"make helm-build"| HELM["Helm Chart"]
-    RBAC -->|"make helm-build"| HELM
-    CHARTS -->|"copied to /charts/<br/>in container image"| RUNTIME["Helm renderer<br/>in operator"]
+    CHARTS -->|"COPY in Dockerfile"| IMAGE["Operator container image<br/>/charts/"]
 ```
 
-## Cluster State After Installation (no Kuadrant CR)
+The kuadrant-operator OLM bundle and Helm chart contain only the kuadrant-operator's own resources (CRDs, Deployment, RBAC). Child operator resources are not included in the bundle or Helm chart.
+
+## Cluster State After Installation (before Kuadrant CR)
 
 ```mermaid
 graph TB
-    subgraph operator["1 Operator Deployment"]
+    subgraph operator-ns["Operator namespace (e.g. kuadrant-system)"]
         KOP["kuadrant-operator"]
+        AO["authorino-operator"]
+        LO["limitador-operator"]
+        DO["dns-operator"]
+        MG["mcp-gateway controller"]
     end
 
-    subgraph crds["CRDs (all installed by kuadrant-operator bundle/chart)"]
+    subgraph crds["CRDs"]
         K_CRD["Kuadrant, AuthPolicy<br/>RateLimitPolicy, DNSPolicy<br/>TLSPolicy"]
         A_CRD["Authorino, AuthConfig"]
         L_CRD["Limitador"]
@@ -87,13 +74,23 @@ graph TB
         M_CRD["MCPGatewayExtension<br/>MCPServerRegistration<br/>MCPVirtualServer"]
     end
 
-    subgraph rbac["RBAC"]
-        K_RBAC["kuadrant-operator<br/>SA + ClusterRole + CRB"]
-        CHILD_CR["Child operator ClusterRoles<br/>(no SA or CRB yet)"]
+    subgraph installed-by["Installed by"]
+        INSTALLER["Helm or OLM"] -.-> K_CRD
+        INSTALLER -.-> KOP
+        KOP -->|"renders charts<br/>at startup"| AO
+        KOP -->|"renders charts<br/>at startup"| LO
+        KOP -->|"renders charts<br/>at startup"| DO
+        KOP -->|"renders charts<br/>at startup"| MG
+        KOP -->|"applies CRDs<br/>at startup"| A_CRD
+        KOP -->|"applies CRDs<br/>at startup"| L_CRD
+        KOP -->|"applies CRDs<br/>at startup"| D_CRD
+        KOP -->|"applies CRDs<br/>at startup"| M_CRD
     end
 
-    KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No child operators running<br/>until user creates Kuadrant CR"]
+    KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No data plane workloads yet<br/>Child controllers already running"]
 ```
+
+All child operator controllers, CRDs, and ClusterRoles are deployed at operator startup before the controller manager begins watching resources. No Kuadrant CR is needed for the control plane to be running.
 
 ## Runtime: Reconciliation Chain
 
@@ -104,15 +101,15 @@ graph TB
 
     subgraph operator-ns["Operator namespace (e.g. kuadrant-system)"]
         KOP["kuadrant-operator"]
+        AO["authorino-operator"]
+        LO["limitador-operator"]
+        DO["dns-operator"]
+        MG["mcp-gateway controller"]
     end
 
     KCR -->|"triggers"| KOP
 
-    subgraph kuadrant-ns["Kuadrant CR namespace"]
-        AO["authorino-operator<br/>Deployment + SA + CRB"]
-        LO["limitador-operator<br/>Deployment + SA + CRB"]
-        DO["dns-operator<br/>Deployment + SA + CRB"]
-        MG["mcp-gateway controller<br/>Deployment + SA + CRB"]
+    subgraph kuadrant-cr-ns["Kuadrant CR namespace"]
         ACR["Authorino CR"]
         LCR["Limitador CR"]
         AW["Authorino Deployment"]
@@ -120,10 +117,6 @@ graph TB
         MGW["MCP broker + router"]
     end
 
-    KOP -->|"renders chart"| AO
-    KOP -->|"renders chart"| LO
-    KOP -->|"renders chart"| DO
-    KOP -->|"renders chart"| MG
     KOP -->|"creates wrapper CR"| ACR
     KOP -->|"creates wrapper CR"| LCR
 
@@ -135,6 +128,8 @@ graph TB
     LCR --> LW
     MGCR --> MGW
 ```
+
+Child operator controllers are already running in the operator namespace (deployed at startup). When a user creates a Kuadrant CR, kuadrant-operator creates wrapper CRs (Authorino CR, Limitador CR) in the Kuadrant CR's namespace. The child operators reconcile these into data plane workloads. MCPGatewayExtension is created directly by the user.
 
 ## RBAC Model
 
@@ -149,7 +144,7 @@ graph LR
     end
 
     subgraph roles["ClusterRoles"]
-        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ bind on child roles"]
+        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ escalate/bind on child roles<br/>+ CRD create"]
         AR["authorino-operator-manager<br/>authorino-manager-role<br/>authorino-manager-k8s-auth-role"]
         LR_["limitador-operator-manager-role"]
         DR["dns-operator-manager-role<br/>dns-operator-remote-cluster-role"]
@@ -158,21 +153,28 @@ graph LR
 
     subgraph who["Created by"]
         OLM_H["Helm or OLM"]
-        KUADRANT["kuadrant-operator<br/>at runtime"]
+        KUADRANT["kuadrant-operator<br/>at startup"]
     end
 
-    OLM_H -->|"ClusterRoleBinding"| KSA
+    OLM_H -->|"installs"| KSA
+    OLM_H -->|"installs"| KR
     KSA --> KR
 
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| ASA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| LSA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| DSA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| MSA
+    KUADRANT -->|"creates ClusterRole<br/>using escalate"| AR
+    KUADRANT -->|"creates ClusterRole<br/>using escalate"| LR_
+    KUADRANT -->|"creates ClusterRole<br/>using escalate"| DR
+    KUADRANT -->|"creates ClusterRole<br/>using escalate"| MR
+    KUADRANT -->|"creates CRB<br/>using bind"| ASA
+    KUADRANT -->|"creates CRB<br/>using bind"| LSA
+    KUADRANT -->|"creates CRB<br/>using bind"| DSA
+    KUADRANT -->|"creates CRB<br/>using bind"| MSA
     ASA --> AR
     LSA --> LR_
     DSA --> DR
     MSA --> MR
 ```
+
+The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All child operator ClusterRoles, SAs, and CRBs are created by the kuadrant-operator at startup using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
 
 ## Resource Ownership
 
@@ -180,21 +182,37 @@ graph LR
 graph TB
     USER["User"] -->|"creates"| KCR["Kuadrant CR"]
     USER -->|"creates"| POLICIES["AuthPolicy, RateLimitPolicy<br/>DNSPolicy, TLSPolicy"]
+    USER -->|"creates"| MGCR["MCPGatewayExtension CR"]
 
     subgraph installer["Installed by Helm or OLM"]
-        CRDs["All CRDs"]
-        CR["Component ClusterRoles"]
+        KOP_CRDs["kuadrant-operator CRDs"]
         KOP_DEP["kuadrant-operator Deployment"]
         KOP_RBAC["kuadrant-operator SA, ClusterRole, CRB"]
     end
 
-    KCR -->|"ownerRef"| AUTH_OP["authorino-operator Deployment"]
-    KCR -->|"ownerRef"| LIM_OP["limitador-operator Deployment"]
-    KCR -->|"ownerRef"| DNS_OP["dns-operator Deployment"]
-    KCR -->|"ownerRef"| MCP_OP["mcp-gateway Deployment"]
-    KCR -->|"ownerRef"| AUTH_CR["Authorino CR"]
-    KCR -->|"ownerRef"| LIM_CR["Limitador CR"]
+    subgraph startup["Deployed by kuadrant-operator at startup"]
+        CHILD_CRDs["Child operator CRDs"]
+        CHILD_CR["Child operator ClusterRoles"]
+        AUTH_OP["authorino-operator Deployment + SA + CRB"]
+        LIM_OP["limitador-operator Deployment + SA + CRB"]
+        DNS_OP["dns-operator Deployment + SA + CRB"]
+        MCP_OP["mcp-gateway Deployment + SA + CRB"]
+    end
 
-    AUTH_CR -->|"ownerRef"| AUTH_WL["Authorino Deployment"]
-    LIM_CR -->|"ownerRef"| LIM_WL["Limitador Deployment"]
+    subgraph kuadrant-cr["Triggered by Kuadrant CR"]
+        AUTH_CR["Authorino CR"]
+        LIM_CR["Limitador CR"]
+    end
+
+    KCR --> AUTH_CR
+    KCR --> LIM_CR
+
+    AUTH_CR -->|"reconciled by<br/>authorino-operator"| AUTH_WL["Authorino Deployment"]
+    LIM_CR -->|"reconciled by<br/>limitador-operator"| LIM_WL["Limitador Deployment"]
+    MGCR -->|"reconciled by<br/>mcp-gateway"| MCP_WL["MCP broker + router"]
 ```
+
+Three layers of resource ownership:
+1. **Installer** (Helm/OLM): kuadrant-operator's own resources only
+2. **kuadrant-operator at startup**: child operator CRDs, ClusterRoles, controllers (not tied to any CR)
+3. **kuadrant-operator via Kuadrant CR**: wrapper CRs that trigger data plane workloads

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -101,22 +101,39 @@ graph TB
 graph TB
     USER["User"] -->|"creates"| KCR["Kuadrant CR"]
     USER -->|"creates"| MGCR["MCPGatewayExtension CR"]
-    KCR -->|"triggers"| KOP["kuadrant-operator"]
 
-    KOP -->|"renders /charts/authorino-operator"| AO["authorino-operator<br/>Deployment + SA + CRB"]
-    KOP -->|"renders /charts/limitador-operator"| LO["limitador-operator<br/>Deployment + SA + CRB"]
-    KOP -->|"renders /charts/dns-operator"| DO["dns-operator<br/>Deployment + SA + CRB"]
-    KOP -->|"renders /charts/mcp-gateway"| MG["mcp-gateway controller<br/>Deployment + SA + CRB"]
-    KOP -->|"creates wrapper CR"| ACR["Authorino CR"]
-    KOP -->|"creates wrapper CR"| LCR["Limitador CR"]
+    subgraph operator-ns["Operator namespace (e.g. kuadrant-system)"]
+        KOP["kuadrant-operator"]
+    end
+
+    KCR -->|"triggers"| KOP
+
+    subgraph kuadrant-ns["Kuadrant CR namespace"]
+        AO["authorino-operator<br/>Deployment + SA + CRB"]
+        LO["limitador-operator<br/>Deployment + SA + CRB"]
+        DO["dns-operator<br/>Deployment + SA + CRB"]
+        MG["mcp-gateway controller<br/>Deployment + SA + CRB"]
+        ACR["Authorino CR"]
+        LCR["Limitador CR"]
+        AW["Authorino Deployment"]
+        LW["Limitador Deployment"]
+        MGW["MCP broker + router"]
+    end
+
+    KOP -->|"renders chart"| AO
+    KOP -->|"renders chart"| LO
+    KOP -->|"renders chart"| DO
+    KOP -->|"renders chart"| MG
+    KOP -->|"creates wrapper CR"| ACR
+    KOP -->|"creates wrapper CR"| LCR
 
     AO -->|"reconciles"| ACR
     LO -->|"reconciles"| LCR
     MG -->|"reconciles"| MGCR
 
-    ACR --> AW["Authorino Deployment"]
-    LCR --> LW["Limitador Deployment"]
-    MGCR --> MGW["MCP broker + router"]
+    ACR --> AW
+    LCR --> LW
+    MGCR --> MGW
 ```
 
 ## RBAC Model

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -8,7 +8,7 @@
 | **CRB** | ClusterRoleBinding |
 | **SA** | ServiceAccount |
 | **CRD** | CustomResourceDefinition |
-| **bind/escalate** | RBAC verbs that allow creating ClusterRoleBindings to named ClusterRoles without holding all their permissions |
+| **bind** | RBAC verb that allows creating ClusterRoleBindings to named ClusterRoles without holding all their permissions |
 | **GITREF** | Git reference (branch, tag, or SHA) used to pull charts from upstream repos |
 | **Wrapper CR** | Authorino/Limitador custom resources created by kuadrant-operator and reconciled by child operators |
 
@@ -100,21 +100,23 @@ graph TB
 ```mermaid
 graph TB
     USER["User"] -->|"creates"| KCR["Kuadrant CR"]
+    USER -->|"creates"| MGCR["MCPGatewayExtension CR"]
     KCR -->|"triggers"| KOP["kuadrant-operator"]
 
     KOP -->|"renders /charts/authorino-operator"| AO["authorino-operator<br/>Deployment + SA + CRB"]
     KOP -->|"renders /charts/limitador-operator"| LO["limitador-operator<br/>Deployment + SA + CRB"]
     KOP -->|"renders /charts/dns-operator"| DO["dns-operator<br/>Deployment + SA + CRB"]
-    KOP -->|"renders /charts/mcp-gateway"| MG["mcp-gateway<br/>Deployment + SA + CRB"]
+    KOP -->|"renders /charts/mcp-gateway"| MG["mcp-gateway controller<br/>Deployment + SA + CRB"]
     KOP -->|"creates wrapper CR"| ACR["Authorino CR"]
     KOP -->|"creates wrapper CR"| LCR["Limitador CR"]
 
     AO -->|"reconciles"| ACR
     LO -->|"reconciles"| LCR
+    MG -->|"reconciles"| MGCR
 
     ACR --> AW["Authorino Deployment"]
     LCR --> LW["Limitador Deployment"]
-    MG --> MGW["MCP broker + router"]
+    MGCR --> MGW["MCP broker + router"]
 ```
 
 ## RBAC Model
@@ -130,7 +132,7 @@ graph LR
     end
 
     subgraph roles["ClusterRoles"]
-        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ bind/escalate on child roles"]
+        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ bind on child roles"]
         AR["authorino-operator-manager<br/>authorino-manager-role<br/>authorino-manager-k8s-auth-role"]
         LR_["limitador-operator-manager-role"]
         DR["dns-operator-manager-role<br/>dns-operator-remote-cluster-role"]
@@ -145,10 +147,10 @@ graph LR
     OLM_H -->|"ClusterRoleBinding"| KSA
     KSA --> KR
 
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| ASA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| LSA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| DSA
-    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| MSA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| ASA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| LSA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| DSA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind"| MSA
     ASA --> AR
     LSA --> LR_
     DSA --> DR

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -1,0 +1,181 @@
+# Kuadrant Operator Consolidation: Architecture Diagrams
+
+## Key
+
+| Term | Meaning |
+|------|---------|
+| **SSA** | Server-Side Apply — Kubernetes apply method where the server tracks field ownership per manager |
+| **CRB** | ClusterRoleBinding |
+| **SA** | ServiceAccount |
+| **CRD** | CustomResourceDefinition |
+| **bind/escalate** | RBAC verbs that allow creating ClusterRoleBindings to named ClusterRoles without holding all their permissions |
+| **GITREF** | Git reference (branch, tag, or SHA) used to pull charts from upstream repos |
+| **Wrapper CR** | Authorino/Limitador custom resources created by kuadrant-operator and reconciled by child operators |
+
+## Build-Time: Chart Sync and Packaging
+
+```mermaid
+graph LR
+    subgraph upstream["Upstream Repos"]
+        AO["Kuadrant/authorino-operator"]
+        LO["Kuadrant/limitador-operator"]
+        DO["Kuadrant/dns-operator"]
+        MG["Kuadrant/mcp-gateway"]
+    end
+
+    SYNC["make sync-child-operator-charts<br/>Go tool: hack/sync-child-charts/"]
+
+    AO -->|GITREF| SYNC
+    LO -->|GITREF| SYNC
+    DO -->|GITREF| SYNC
+    MG -->|GITREF| SYNC
+
+    subgraph local["config/child-operators/"]
+        subgraph crds["crds/"]
+            ao_c["authorino-operator.yaml"]
+            lo_c["limitador-operator.yaml"]
+            do_c["dns-operator.yaml"]
+            mg_c["mcp-gateway.yaml"]
+        end
+        subgraph rbac["rbac/"]
+            ao_r["authorino-operator.yaml"]
+            lo_r["limitador-operator.yaml"]
+            do_r["dns-operator.yaml"]
+            mg_r["mcp-gateway.yaml"]
+        end
+        subgraph charts["charts/"]
+            ao_t["authorino-operator/"]
+            lo_t["limitador-operator/"]
+            do_t["dns-operator/"]
+            mg_t["mcp-gateway/"]
+        end
+    end
+
+    SYNC --> crds
+    SYNC --> rbac
+    SYNC --> charts
+```
+
+```mermaid
+graph LR
+    subgraph local["config/child-operators/"]
+        CRDs["crds/"]
+        RBAC["rbac/"]
+        CHARTS["charts/"]
+    end
+
+    CRDs -->|"make bundle"| BUNDLE["OLM Bundle"]
+    RBAC -->|"make bundle"| BUNDLE
+    CRDs -->|"make helm-build"| HELM["Helm Chart"]
+    RBAC -->|"make helm-build"| HELM
+    CHARTS -->|"copied to /charts/<br/>in container image"| RUNTIME["Helm renderer<br/>in operator"]
+```
+
+## Cluster State After Installation (no Kuadrant CR)
+
+```mermaid
+graph TB
+    subgraph operator["1 Operator Deployment"]
+        KOP["kuadrant-operator"]
+    end
+
+    subgraph crds["CRDs (all installed by kuadrant-operator bundle/chart)"]
+        K_CRD["Kuadrant, AuthPolicy<br/>RateLimitPolicy, DNSPolicy<br/>TLSPolicy"]
+        A_CRD["Authorino, AuthConfig"]
+        L_CRD["Limitador"]
+        D_CRD["DNSRecord<br/>DNSHealthCheckProbe"]
+        M_CRD["MCPGatewayExtension<br/>MCPServerRegistration<br/>MCPVirtualServer"]
+    end
+
+    subgraph rbac["RBAC"]
+        K_RBAC["kuadrant-operator<br/>SA + ClusterRole + CRB"]
+        CHILD_CR["Child operator ClusterRoles<br/>(no SA or CRB yet)"]
+    end
+
+    KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No child operators running<br/>until user creates Kuadrant CR"]
+```
+
+## Runtime: Reconciliation Chain
+
+```mermaid
+graph TB
+    USER["User"] -->|"creates"| KCR["Kuadrant CR"]
+    KCR -->|"triggers"| KOP["kuadrant-operator"]
+
+    KOP -->|"renders /charts/authorino-operator"| AO["authorino-operator<br/>Deployment + SA + CRB"]
+    KOP -->|"renders /charts/limitador-operator"| LO["limitador-operator<br/>Deployment + SA + CRB"]
+    KOP -->|"renders /charts/dns-operator"| DO["dns-operator<br/>Deployment + SA + CRB"]
+    KOP -->|"renders /charts/mcp-gateway"| MG["mcp-gateway<br/>Deployment + SA + CRB"]
+    KOP -->|"creates wrapper CR"| ACR["Authorino CR"]
+    KOP -->|"creates wrapper CR"| LCR["Limitador CR"]
+
+    AO -->|"reconciles"| ACR
+    LO -->|"reconciles"| LCR
+
+    ACR --> AW["Authorino Deployment"]
+    LCR --> LW["Limitador Deployment"]
+    MG --> MGW["MCP broker + router"]
+```
+
+## RBAC Model
+
+```mermaid
+graph LR
+    subgraph sa["Service Accounts"]
+        KSA["kuadrant-operator SA"]
+        ASA["authorino-operator SA"]
+        LSA["limitador-operator SA"]
+        DSA["dns-operator SA"]
+        MSA["mcp-gateway SA"]
+    end
+
+    subgraph roles["ClusterRoles"]
+        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ bind/escalate on child roles"]
+        AR["authorino-operator-manager<br/>authorino-manager-role<br/>authorino-manager-k8s-auth-role"]
+        LR_["limitador-operator-manager-role"]
+        DR["dns-operator-manager-role<br/>dns-operator-remote-cluster-role"]
+        MR["mcp-gateway-controller"]
+    end
+
+    subgraph who["Created by"]
+        OLM_H["Helm or OLM"]
+        KUADRANT["kuadrant-operator<br/>at runtime"]
+    end
+
+    OLM_H -->|"ClusterRoleBinding"| KSA
+    KSA --> KR
+
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| ASA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| LSA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| DSA
+    KUADRANT -->|"ClusterRoleBinding<br/>using bind/escalate"| MSA
+    ASA --> AR
+    LSA --> LR_
+    DSA --> DR
+    MSA --> MR
+```
+
+## Resource Ownership
+
+```mermaid
+graph TB
+    USER["User"] -->|"creates"| KCR["Kuadrant CR"]
+    USER -->|"creates"| POLICIES["AuthPolicy, RateLimitPolicy<br/>DNSPolicy, TLSPolicy"]
+
+    subgraph installer["Installed by Helm or OLM"]
+        CRDs["All CRDs"]
+        CR["Component ClusterRoles"]
+        KOP_DEP["kuadrant-operator Deployment"]
+        KOP_RBAC["kuadrant-operator SA, ClusterRole, CRB"]
+    end
+
+    KCR -->|"ownerRef"| AUTH_OP["authorino-operator Deployment"]
+    KCR -->|"ownerRef"| LIM_OP["limitador-operator Deployment"]
+    KCR -->|"ownerRef"| DNS_OP["dns-operator Deployment"]
+    KCR -->|"ownerRef"| MCP_OP["mcp-gateway Deployment"]
+    KCR -->|"ownerRef"| AUTH_CR["Authorino CR"]
+    KCR -->|"ownerRef"| LIM_CR["Limitador CR"]
+
+    AUTH_CR -->|"ownerRef"| AUTH_WL["Authorino Deployment"]
+    LIM_CR -->|"ownerRef"| LIM_WL["Limitador Deployment"]
+```


### PR DESCRIPTION
## Summary

Updates RFC 0019 to reflect the operator consolidation approach. Validated by POC branches on `kuadrant-operator` (`olmv1-umbrella-poc-phase1`, `olmv1-umbrella-poc-static-manifests`) and tested on OpenShift CRC with both OLMv0 and OLMv1.

### Approach

Child operator Helm charts are embedded in the kuadrant-operator container image and rendered at runtime on startup. All child operator resources (CRDs, ClusterRoles, Deployments, SAs, RBAC) are applied by the operator before the controller manager starts. Nothing from child operators is included in the OLM bundle, eliminating GVK migration conflicts entirely.

This follows the same pattern used by Red Hat OpenShift AI ([opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator)) and OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator), and is the approach recommended by the OLM team for operators that previously relied on dependency declarations.

### Key decisions

- Child operators are control plane singletons deployed in the operator namespace at startup, not triggered by Kuadrant CR
- Charts consumed as-is from upstream repos, no rendering or splitting at sync time
- OLM bundle contains only kuadrant-operator's own CRDs and resources
- OLM migration handled programmatically (operator cleans up orphaned child Subscriptions/CSVs)
- OLMv1 compatibility verified via ClusterExtension on CRC
- RBAC: scoped CRD permissions (unscoped `create`, scoped `get`/`update`/`patch`), `escalate` for ClusterRoles, `bind` for ClusterRoleBindings
- Kuadrant CR only triggers data plane (wrapper CRs, policies)

### Alternatives considered and rejected

- Installer-managed CRDs (split chart approach): OLM GVK conflicts, divergent deployment model
- Consolidated CSV (large CSV): OLM GVK conflicts, no path to conditional deployment
- Operator-managed Subscriptions: OLMv0-only API, two separate code paths for OLM/Helm
- New umbrella operator: unnecessary new codebase
- Manual dependency installation: UX regression

### POC Branches

- `kuadrant-operator`: [`olmv1-umbrella-poc-phase1`](https://github.com/Kuadrant/kuadrant-operator/tree/olmv1-umbrella-poc-phase1) (runtime rendering)
- `kuadrant-operator`: [`olmv1-umbrella-poc-static-manifests`](https://github.com/Kuadrant/kuadrant-operator/tree/olmv1-umbrella-poc-static-manifests) (consolidated CSV alternative)
- `dns-operator`: [`olmv1-umbrella-poc-phase1`](https://github.com/Kuadrant/dns-operator/tree/olmv1-umbrella-poc-phase1)