### PR TITLE
docs: update RFC 0019 for KuadrantControlPlane CRD and chart sync tooling

### DIFF
--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -90,7 +90,7 @@ component-charts/
 └── mcp-gateway/            # Complete upstream chart
 ```
 
-Charts are copied as-is from upstream with no rendering, splitting, or modification. The complete chart (Chart.yaml, values.yaml, templates/, crds/) is preserved so the operator can render it at runtime exactly as it would be used in a standalone Helm installation. The sync tool resolves the tracked branch to a commit SHA and pins it in `sync.yaml` for reproducibility.
+Charts are copied as-is from upstream with no rendering, splitting, or modification. The complete chart (Chart.yaml, values.yaml, templates/, crds/) is preserved so the operator can render it at runtime exactly as it would be used in a standalone Helm installation. The sync tool resolves the tracked branch to its latest commit SHA and updates only the `ref` field in `sync.yaml` for reproducibility. The `tracked-branch` field remains unchanged and continues to identify which upstream branch to follow.
 
 Synced charts are committed to the repo. The sync is run manually via `make sync-component-charts` or triggered automatically via `repository_dispatch` from component repos. Charts are also packaged into the operator container image for runtime access.
 
@@ -102,7 +102,7 @@ All child operator resources are managed by the kuadrant-operator at runtime. Th
 
 | Resource | Notes |
 |---|---|
-| kuadrant-operator CRDs | Kuadrant, AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, TokenRateLimitPolicy |
+| kuadrant-operator CRDs | Kuadrant, AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, TokenRateLimitPolicy, KuadrantControlPlane |
 | kuadrant-operator Deployment | The operator itself |
 | kuadrant-operator ServiceAccount, ClusterRole, ClusterRoleBinding | Operator's own RBAC |
 
@@ -126,11 +126,52 @@ All child operator resources are managed by the kuadrant-operator at runtime. Th
 
 Child operator CRDs are not included in the OLM bundle. This is a deliberate choice that eliminates GVK conflicts during OLM upgrades from the current multi-operator installation (see [Migration](#migration-from-multi-operator-olm-installation)).
 
+## KuadrantControlPlane CRD
+
+A new cluster-scoped singleton CRD (`KuadrantControlPlane`) drives component deployment and reports control plane health. This separates control plane management (which components are deployed, their status) from data plane management (the Kuadrant CR, policies, workloads), following the same pattern used by RHOAI/RHODS where `DSCInitialization` handles platform setup separately from `DataScienceCluster`.
+
+The operator auto-creates a default `KuadrantControlPlane` CR named `default` on startup. CEL validation enforces the singleton constraint, the API server rejects any CR not named `default`. If deleted, the controller immediately re-creates it (self-healing). Child operator resources have no `ownerReferences` pointing to the CR, so deletion does not cascade.
+
+The CRD has no spec fields initially, all components are always deployed.
+
+### Status
+
+```yaml
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: ComponentsHealthy
+  components:
+    - name: dns-operator
+      ready: true
+      image: quay.io/kuadrant/dns-operator:latest
+      crds:
+        - name: dnsrecords.kuadrant.io
+          established: true
+        - name: dnshealthcheckprobes.kuadrant.io
+          established: true
+```
+
+The `Ready` condition reflects overall control plane health. Per-component status reports Deployment readiness, the deployed image reference, and CRD establishment state.
+
+### Controller
+
+The KuadrantControlPlane controller is a standard controller-runtime reconciler, separate from the PolicyMachineryController (which handles data plane policies). Both run via the same controller-runtime manager. The controller watches child operator Deployments and CRDs via predicates, so status converges immediately when a Deployment becomes ready or a CRD is established. A periodic 5-minute resync provides drift reconciliation as a safety net.
+
 ## Runtime rendering
 
-On startup, before the controller manager begins watching resources, the kuadrant-operator renders each component controller's Helm chart from `/charts/<name>/` in the container image using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`). This is the same pattern used by OpenShift's [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) and [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) in production.
+On startup, the kuadrant-operator bootstraps child operator CRDs before the controller manager starts. This is required because the PolicyMachineryController's `BootOptionsBuilder` checks for CRD availability at boot time and does not re-check, CRDs created after boot are not detected. Only CRDs are applied pre-manager; all other resources are deployed by the KuadrantControlPlane controller during reconciliation.
 
-Charts are rendered and applied following Helm's install ordering (CRDs first, then dependent resources). All child operator resources must be established before the controller manager starts watching for CRDs.
+The startup sequence:
+
+1. **Pre-manager CRD bootstrap**: render each component chart using the Helm Go SDK (`ClientOnly=true`, `DryRun=true`), extract CRDs, apply via Server-Side Apply, wait for each CRD to reach the `Established` condition (30s timeout per CRD)
+2. **Manager starts**: the KuadrantControlPlane controller and PolicyMachineryController both start
+3. **KuadrantControlPlane reconciliation**: on the first reconcile (triggered by the auto-created CR), the controller renders each component chart, applies all resources (CRDs again via SSA, idempotent, plus RBAC, Deployments, Services, etc.) sorted by Helm install order, and updates the CR status
+4. **Drift reconciliation**: subsequent reconciles (every 5 minutes, or immediately when a watched Deployment/CRD changes) re-apply all resources via SSA, correcting any drift
+
+Charts are rendered from `/charts/<name>/` in the container image. CRDs from both the standard `crds/` directory and `templates/` are handled, the renderer extracts CRDs from `chart.CRDObjects()` and identifies `CustomResourceDefinition` objects in the template output.
 
 Component controllers are deployed into the kuadrant-operator's namespace (e.g. `kuadrant-system`). They are control plane singletons, one instance per cluster, not per Kuadrant CR. This matches the current model where OLM deploys all child operators into the same namespace.
 
@@ -140,7 +181,7 @@ Component controller Deployments are not owned by the Kuadrant CR. They run inde
 
 The kuadrant-operator requires permissions to create and manage all child operator resources at runtime:
 
-- **`apiextensions.k8s.io` CRDs**: unscoped `create` (required because the resource may not exist yet), plus `get`, `list`, `watch`, `update`, `patch` scoped to specific child CRD names via `resourceNames`. This ensures the operator can only modify CRDs it manages while limiting the broad permission to `create` only
+- **`apiextensions.k8s.io` CRDs**: unscoped `create`, `list`, `watch` (required because the resource may not exist yet, and the controller-runtime informer cache requires `list`/`watch` at cluster scope), plus `get`, `update`, `patch` scoped to specific child CRD names via `resourceNames`. This ensures the operator can only modify CRDs it manages while limiting the broad permissions to `create`, `list`, and `watch` only
 - **`rbac.authorization.k8s.io` ClusterRoles**: unscoped `create` (same reason as CRDs), plus `get`, `list`, `watch`, `update`, `patch`, `bind`, `escalate` scoped to specific child ClusterRole names via `resourceNames`
 - **`rbac.authorization.k8s.io` ClusterRoleBindings, Roles, RoleBindings**: standard CRUD to bind component SAs to their ClusterRoles
 - **`apps` Deployments, core resources**: standard CRUD for component controllers
@@ -168,6 +209,12 @@ OLM convention requires all container images to be declared in the CSV's `relate
 | `RELATED_IMAGE_MCP_GATEWAY` | `ghcr.io/kuadrant/mcp-controller:latest` | MCP Gateway controller |
 
 These are declared as environment variables on the kuadrant-operator Deployment (`config/manager/manager.yaml`). The downstream build system overrides them with version-pinned or mirrored image references. The Helm rendering reads these env vars and applies the correct images when rendering child operator charts, either by patching the rendered Deployment image directly (for simple charts that don't support values-based overrides) or by passing Helm values (for charts with configurable image fields).
+
+## Resource labelling
+
+All resources rendered from child operator Helm charts are stamped with `app.kubernetes.io/managed-by: kuadrant-operator` during rendering, overriding any `managed-by` label set by the chart templates (typically `helm`). This ensures child operator resources are clearly identified as managed by the kuadrant-operator, not by Helm or OLM. The label is applied to all resource types including CRDs.
+
+During OLM migration, the cleanup process strips stale OLM labels (`olm.managed`, `olm.owner`, `olm.owner.kind`, `olm.owner.namespace`, `olm.deployment-spec-hash`, `operators.coreos.com/*`) and CSV `ownerReferences` from all resources previously owned by orphaned child operator CSVs. Combined with the `managed-by: kuadrant-operator` label from chart rendering, this ensures a clean transition from OLM ownership to kuadrant-operator ownership with no stale metadata.
 
 ## Wrapper CRs preserved
 
@@ -206,9 +253,13 @@ Since child operator CRDs are not included in the OLM bundle, there are no GVK c
 
 On startup, the upgraded kuadrant-operator:
 
-1. Applies child operator CRDs (which already exist from the previous installation)
-2. Deploys child operator controllers from embedded Helm charts
-3. Detects and removes orphaned child operator Subscriptions and CSVs programmatically
+1. Bootstraps child operator CRDs via SSA (which already exist from the previous installation, SSA is a no-op for unchanged CRDs)
+2. Creates a default `KuadrantControlPlane` CR
+3. The KuadrantControlPlane controller deploys child operator controllers from embedded Helm charts, with `app.kubernetes.io/managed-by: kuadrant-operator` stamped on all resources
+4. Detects and removes orphaned child operator Subscriptions and CSVs programmatically
+5. Strips stale OLM labels (`olm.*`, `operators.coreos.com/*`) and CSV `ownerReferences` from all resources previously owned by orphaned child operator CSVs. Resources are discovered dynamically via `olm.owner` and `operators.coreos.com/<package>.<namespace>` label selectors, no hardcoded resource type list
+
+The OLM cleanup runs once at startup (not during reconciliation) and is designed to be removed after 2-3 releases, once all users have upgraded past the consolidation release.
 
 The data plane (Authorino server, Limitador server) is unaffected throughout. Verified on OpenShift CRC: deleting child operator CSVs removes their controller Deployments but does not cascade-delete CRDs, ClusterRoles, or data plane workloads. The consolidated operator's child controllers take over seamlessly.
 
@@ -236,15 +287,14 @@ These tests should run in CI for every release and serve as ongoing regression t
 This RFC deliberately preserves wrapper CRs and child operator controllers. A follow-on RFC should address further architectural simplification:
 
 - **Removing intermediate operator layers and wrapper CRs**: deploying Authorino and Limitador workloads directly from the kuadrant-operator, eliminating authorino-operator and limitador-operator as running controllers. This removes the `Authorino` and `Limitador` CRDs from the user-facing API surface. Each operator removed is a separate container image with its own Go dependency tree. Every transitive dependency is a potential CVE that needs scanning, patching, and releasing. Removing these controllers reduces the security surface area and maintenance burden.
-- **Control plane status CR**: a new cluster-scoped CR (e.g. `KuadrantControlPlane` or `KuadrantPlatform`, separate from the Kuadrant CR) for reporting child operator health and eventually enabling conditional component deployment. The operator would auto-create a default on startup. This separates control plane management (which components are deployed, their health) from data plane management (the Kuadrant CR, policies, workloads). This is the same pattern used by RHOAI/RHODS, where `DSCInitialization` handles platform setup and `DataScienceCluster` controls component lifecycle.
-- **Conditional component deployment**: using the control plane CR to allow operators to be selectively enabled or disabled, avoiding deploying components that are not needed (e.g. mcp-gateway on clusters without Istio).
+- **Conditional component deployment**: using the KuadrantControlPlane CR spec to allow operators to be selectively enabled or disabled, avoiding deploying components that are not needed (e.g. mcp-gateway on clusters without Istio). The KuadrantControlPlane CRD is already implemented with status reporting; adding per-component `ManagementState` (Managed/Removed) fields to the spec is the next step.
 - **Extracting a dedicated policy controller**: separating policy reconciliation (AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy) from the kuadrant-operator into a `kuadrant-policy-controller` deployed as a component, making the kuadrant-operator purely an orchestration layer.
 - **Kuadrant CR evolution**: exposing day 2 configuration (replicas, resources, storage backend) through the Kuadrant CR.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- **Broader RBAC for kuadrant-operator**: the kuadrant-operator needs an unscoped `create` on `apiextensions.k8s.io` CRDs (scoped `create` is not possible in Kubernetes RBAC since the resource does not exist yet) and `escalate` on ClusterRoles. All other CRD verbs (`get`, `update`, `patch`) are scoped to specific child CRD names. These permissions follow the same pattern used by the OpenShift [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) and [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) in production.
+- **Broader RBAC for kuadrant-operator**: the kuadrant-operator needs unscoped `create`, `list`, and `watch` on `apiextensions.k8s.io` CRDs (scoped `create` is not possible in Kubernetes RBAC since the resource does not exist yet; `list`/`watch` are required at cluster scope for the controller-runtime informer cache) and `escalate` on ClusterRoles. All other CRD verbs (`get`, `update`, `patch`) are scoped to specific child CRD names. These permissions follow the same pattern used by the OpenShift [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) and [cluster-olm-operator](https://github.com/openshift/cluster-olm-operator) in production.
 - **Chart sync maintenance**: component controller charts must be kept in sync. Automated dependency sync (via GitHub dispatch) mitigates this but adds CI complexity.
 - **No OLM CRD protection**: OLM does not know about child operator CRDs, so it cannot prevent another OLM-managed operator from claiming the same GVKs. In practice, this is a narrow risk: it requires installing a standalone child operator via OLM alongside kuadrant, which is a user error. It is worth noting that OLM's GVK protection only prevents conflicts between OLM-managed packages. It does nothing to prevent a Helm chart or raw manifest from altering or replacing a CRD on the cluster.
 - **Startup failure is fatal**: if a child operator chart is malformed or the cluster rejects a resource, the kuadrant-operator will not start. This is a feature, not a bug: it prevents partially-upgraded states where some components are on the new version and others are not. The previous operator pod continues running until the new one is healthy (Deployment rollout strategy).
@@ -333,4 +383,4 @@ Each component published as its own independent OLM package with no dependency d
 
 - **Wrapper CR removal timeline**: this RFC preserves wrapper CRs. The timeline and approach for removing them depends on how much the Authorino and Limitador CRs are used for direct user customisation vs being purely internal. This will be addressed in a follow-on RFC.
 
-- **Control plane status and configuration CR**: the RFC identifies the need for a new CR to report child operator health and eventually enable conditional deployment, but the design of this CR is deferred to implementation.
+- **Control plane status and configuration CR**: ~~the RFC identifies the need for a new CR to report child operator health and eventually enable conditional deployment, but the design of this CR is deferred to implementation.~~ **Resolved**: the `KuadrantControlPlane` CRD has been implemented as a cluster-scoped singleton with per-component status reporting (see [KuadrantControlPlane CRD](#kuadrantcontrolplane-crd) section). Conditional deployment via spec fields is deferred to future work.

--- a/rfcs/0019-olmv1-operator-consolidation.md
+++ b/rfcs/0019-olmv1-operator-consolidation.md
@@ -79,19 +79,20 @@ For visual diagrams covering the build-time chart sync, runtime reconciliation c
 
 ## Chart sync process
 
-Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A sync tool downloads each chart as-is and places it in the operator repo:
+Component Helm charts are sourced from upstream repos (authorino-operator, limitador-operator, dns-operator, mcp-gateway). A sync tool downloads each chart as-is and places it in the operator repo, driven by a config file (`component-charts/sync.yaml`) that declares which upstream repos and branches to track:
 
 ```text
-config/child-operators/charts/
+component-charts/
+├── sync.yaml               # Component tracking config
 ├── authorino-operator/     # Complete upstream chart
 ├── limitador-operator/     # Complete upstream chart
 ├── dns-operator/           # Complete upstream chart
 └── mcp-gateway/            # Complete upstream chart
 ```
 
-Charts are copied as-is from upstream with no rendering, splitting, or modification. The complete chart (Chart.yaml, values.yaml, templates/, crds/) is preserved so the operator can render it at runtime exactly as it would be used in a standalone Helm installation.
+Charts are copied as-is from upstream with no rendering, splitting, or modification. The complete chart (Chart.yaml, values.yaml, templates/, crds/) is preserved so the operator can render it at runtime exactly as it would be used in a standalone Helm installation. The sync tool resolves the tracked branch to a commit SHA and pins it in `sync.yaml` for reproducibility.
 
-Synced charts are committed to the repo. The sync is run manually via `make sync-child-operator-charts` when updating component versions. Charts are also packaged into the operator container image for runtime access.
+Synced charts are committed to the repo. The sync is run manually via `make sync-component-charts` or triggered automatically via `repository_dispatch` from component repos. Charts are also packaged into the operator container image for runtime access.
 
 ## Resource ownership
 
@@ -189,15 +190,13 @@ However, some upstream chart changes would be beneficial:
 
 Since component repos no longer need to produce their own OLM bundles or catalogs, OLM-specific artefacts can also be removed to reduce maintenance burden: `bundle/`, `catalog/`, `config/manifests/`, `config/deploy/olm/`, `config/scorecard/`, `bundle.Dockerfile`, `operator-sdk` and `opm` tool dependencies.
 
-## Automated dependency sync
+## Automated component sync
 
-With the kuadrant-operator consuming charts from multiple child repos, automation is needed to keep them in sync. A pattern for this already exists between authorino and authorino-operator: push to main triggers a `repository_dispatch` to the downstream repo, which runs the sync tool and creates a PR.
+A Go CLI tool (`hack/sync-components/`) manages chart syncing, driven by a config file (`component-charts/sync.yaml`) that declares each component's upstream repo, chart path, tracked branch, and pinned commit SHA (`ref`). The tool resolves the tracked branch to its latest commit SHA, downloads the chart at that SHA, and updates only the `ref` field in the config file. The `tracked-branch` field remains unchanged and continues to identify which upstream branch to follow.
 
-The same pattern should be adopted for the kuadrant-operator. When a child repo's CI completes successfully on a tracked branch, it dispatches to the kuadrant-operator. The sync tool runs, and if there are changes, a PR is created or updated. The automation should manage a single open PR per target branch and child component (e.g. `sync/main/authorino-operator`, `sync/release-v1.5/authorino-operator`), force-updating it on each trigger rather than accumulating stale PRs.
+When a component repo pushes to its tracked branch, a `repository_dispatch` event notifies the kuadrant-operator. A GitHub Actions workflow receives the event, determines which kuadrant-operator branches track that component (currently the default branch only), runs the sync tool, and creates or updates a PR per target branch and component (e.g. `sync/main/dns-operator`).
 
-This automation must support not just `main` but also `release-*` branches. Multiple kuadrant-operator release branches may track different branches of the same child component. For example, `kuadrant-operator/main` may track `authorino-operator/main` while `kuadrant-operator/release-v1.5` tracks `authorino-operator/release-v1.5`.
-
-Changes to the release process and version pinning strategy are out of scope for this RFC and will be addressed separately.
+Release branch sync support is deferred until the branch mapping strategy for releases is defined. Changes to the release process and version pinning strategy are out of scope for this RFC and will be addressed separately.
 
 ## Migration from multi-operator OLM installation
 

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -11,7 +11,7 @@
 | **escalate** | RBAC verb that allows creating ClusterRoles with permissions the creator does not hold |
 | **bind** | RBAC verb that allows creating ClusterRoleBindings to ClusterRoles whose permissions the creator does not hold |
 | **GITREF** | Git reference (branch, tag, or SHA) used to pull charts from upstream repos |
-| **Wrapper CR** | Authorino/Limitador custom resources created by kuadrant-operator and reconciled by child operators |
+| **Wrapper CR** | Authorino/Limitador custom resources created by kuadrant-operator and reconciled by component controllers |
 
 ## Build-Time: Chart Sync and Packaging
 
@@ -24,35 +24,36 @@ graph LR
         MG["Kuadrant/mcp-gateway"]
     end
 
-    SYNC["make sync-child-operator-charts"]
+    SYNC["make sync-component-charts"]
 
-    AO -->|GITREF| SYNC
-    LO -->|GITREF| SYNC
-    DO -->|GITREF| SYNC
-    MG -->|GITREF| SYNC
+    AO -->|"tracked-branch → SHA"| SYNC
+    LO -->|"tracked-branch → SHA"| SYNC
+    DO -->|"tracked-branch → SHA"| SYNC
+    MG -->|"tracked-branch → SHA"| SYNC
 
-    subgraph local["config/child-operators/charts/"]
+    subgraph local["component-charts/"]
+        cfg["sync.yaml<br/>(tracking config)"]
         ao_t["authorino-operator/"]
         lo_t["limitador-operator/"]
         do_t["dns-operator/"]
         mg_t["mcp-gateway/"]
     end
 
-    SYNC -->|"copies chart as-is"| local
+    SYNC -->|"copies chart as-is,<br/>pins commit SHA"| local
 ```
 
-Charts are copied unmodified from upstream repos. No rendering, splitting, or classification at sync time. Each chart directory contains the complete upstream chart (Chart.yaml, values.yaml, templates/, crds/).
+Charts are copied unmodified from upstream repos. No rendering, splitting, or classification at sync time. Each chart directory contains the complete upstream chart (Chart.yaml, values.yaml, templates/, crds/). The sync tool resolves each component's tracked branch to a commit SHA and pins it in `sync.yaml`.
 
 ```mermaid
 graph LR
-    subgraph local["config/child-operators/charts/"]
+    subgraph local["component-charts/"]
         CHARTS["Complete upstream charts"]
     end
 
     CHARTS -->|"COPY in Dockerfile"| IMAGE["Operator container image<br/>/charts/"]
 ```
 
-The kuadrant-operator OLM bundle and Helm chart contain only the kuadrant-operator's own resources (CRDs, Deployment, RBAC). Child operator resources are not included in the bundle or Helm chart.
+The kuadrant-operator OLM bundle and Helm chart contain only the kuadrant-operator's own resources (CRDs, Deployment, RBAC). Component resources are not included in the bundle or Helm chart.
 
 ## Cluster State After Installation (before Kuadrant CR)
 
@@ -87,10 +88,10 @@ graph TB
         KOP -->|"applies CRDs<br/>at startup"| M_CRD
     end
 
-    KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No data plane workloads yet<br/>Child controllers already running"]
+    KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No Kuadrant-managed data plane workloads yet<br/>Component controllers already running"]
 ```
 
-All child operator controllers, CRDs, and ClusterRoles are deployed at operator startup before the controller manager begins watching resources. No Kuadrant CR is needed for the control plane to be running.
+All component controllers, CRDs, and ClusterRoles are deployed at operator startup before the controller manager begins watching resources. No Kuadrant CR is needed for the control plane to be running. MCPGatewayExtension is an exception — it is created directly by the user and reconciled by the mcp-gateway controller independently of the Kuadrant CR.
 
 ## Runtime: Reconciliation Chain
 
@@ -129,7 +130,7 @@ graph TB
     MGCR --> MGW
 ```
 
-Child operator controllers are already running in the operator namespace (deployed at startup). When a user creates a Kuadrant CR, kuadrant-operator creates wrapper CRs (Authorino CR, Limitador CR) in the Kuadrant CR's namespace. The child operators reconcile these into data plane workloads. MCPGatewayExtension is created directly by the user.
+Component controllers are already running in the operator namespace (deployed at startup). When a user creates a Kuadrant CR, kuadrant-operator creates wrapper CRs (Authorino CR, Limitador CR) in the Kuadrant CR's namespace. The component controllers reconcile these into data plane workloads. MCPGatewayExtension is created directly by the user.
 
 ## RBAC Model
 
@@ -144,7 +145,7 @@ graph LR
     end
 
     subgraph roles["ClusterRoles"]
-        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ escalate/bind on child roles<br/>+ CRD create"]
+        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ escalate/bind on component roles<br/>+ CRD create"]
         AR["authorino-operator-manager<br/>authorino-manager-role<br/>authorino-manager-k8s-auth-role"]
         LR_["limitador-operator-manager-role"]
         DR["dns-operator-manager-role<br/>dns-operator-remote-cluster-role"]
@@ -174,7 +175,7 @@ graph LR
     MSA --> MR
 ```
 
-The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All child operator ClusterRoles, SAs, and CRBs are created by the kuadrant-operator at startup using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
+The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All component ClusterRoles, SAs, and CRBs are created by the kuadrant-operator at startup using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
 
 ## Resource Ownership
 
@@ -191,8 +192,8 @@ graph TB
     end
 
     subgraph startup["Deployed by kuadrant-operator at startup"]
-        CHILD_CRDs["Child operator CRDs"]
-        CHILD_CR["Child operator ClusterRoles"]
+        COMP_CRDs["Component CRDs"]
+        COMP_CR["Component ClusterRoles"]
         AUTH_OP["authorino-operator Deployment + SA + CRB"]
         LIM_OP["limitador-operator Deployment + SA + CRB"]
         DNS_OP["dns-operator Deployment + SA + CRB"]
@@ -214,5 +215,5 @@ graph TB
 
 Three layers of resource ownership:
 1. **Installer** (Helm/OLM): kuadrant-operator's own resources only
-2. **kuadrant-operator at startup**: child operator CRDs, ClusterRoles, controllers (not tied to any CR)
+2. **kuadrant-operator at startup**: component CRDs, ClusterRoles, controllers (not tied to any CR)
 3. **kuadrant-operator via Kuadrant CR**: wrapper CRs that trigger data plane workloads

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -90,10 +90,11 @@ graph TB
     end
 
     KOP -->|"auto-creates"| KCP
-    KCP -->|"triggers<br/>reconciliation"| AO
-    KCP -->|"triggers<br/>reconciliation"| LO
-    KCP -->|"triggers<br/>reconciliation"| DO
-    KCP -->|"triggers<br/>reconciliation"| MG
+    KCP -->|"reconciled by<br/>KuadrantControlPlane<br/>controller"| DEPLOY["Deploys component<br/>Deployments, RBAC,<br/>Services, ConfigMaps"]
+    DEPLOY --> AO
+    DEPLOY --> LO
+    DEPLOY --> DO
+    DEPLOY --> MG
 
     KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No Kuadrant-managed data plane workloads yet<br/>Component controllers already running"]
 ```
@@ -165,28 +166,30 @@ graph LR
 
     subgraph who["Created by"]
         OLM_H["Helm or OLM"]
-        KUADRANT["kuadrant-operator<br/>at startup"]
+        KCP_CTRL["KuadrantControlPlane<br/>controller"]
+        BOOTSTRAP["Pre-manager<br/>CRD bootstrap"]
     end
 
     OLM_H -->|"installs"| KSA
     OLM_H -->|"installs"| KR
     KSA --> KR
 
-    KUADRANT -->|"creates ClusterRole<br/>using escalate"| AR
-    KUADRANT -->|"creates ClusterRole<br/>using escalate"| LR_
-    KUADRANT -->|"creates ClusterRole<br/>using escalate"| DR
-    KUADRANT -->|"creates ClusterRole<br/>using escalate"| MR
-    KUADRANT -->|"creates CRB<br/>using bind"| ASA
-    KUADRANT -->|"creates CRB<br/>using bind"| LSA
-    KUADRANT -->|"creates CRB<br/>using bind"| DSA
-    KUADRANT -->|"creates CRB<br/>using bind"| MSA
+    BOOTSTRAP -->|"applies component<br/>CRDs only"| AR
+    KCP_CTRL -->|"creates ClusterRole<br/>using escalate"| AR
+    KCP_CTRL -->|"creates ClusterRole<br/>using escalate"| LR_
+    KCP_CTRL -->|"creates ClusterRole<br/>using escalate"| DR
+    KCP_CTRL -->|"creates ClusterRole<br/>using escalate"| MR
+    KCP_CTRL -->|"creates CRB<br/>using bind"| ASA
+    KCP_CTRL -->|"creates CRB<br/>using bind"| LSA
+    KCP_CTRL -->|"creates CRB<br/>using bind"| DSA
+    KCP_CTRL -->|"creates CRB<br/>using bind"| MSA
     ASA --> AR
     LSA --> LR_
     DSA --> DR
     MSA --> MR
 ```
 
-The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All component ClusterRoles, SAs, and CRBs are created by the kuadrant-operator via the KuadrantControlPlane controller using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
+The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. Component CRDs are bootstrapped pre-manager (before the controller manager starts). All other component resources (ClusterRoles, SAs, CRBs, Deployments, Services) are created by the KuadrantControlPlane controller using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
 
 ## Resource Ownership
 

--- a/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
+++ b/rfcs/0019-olmv1-operator-consolidation/architecture-diagrams.md
@@ -68,30 +68,41 @@ graph TB
     end
 
     subgraph crds["CRDs"]
-        K_CRD["Kuadrant, AuthPolicy<br/>RateLimitPolicy, DNSPolicy<br/>TLSPolicy"]
+        K_CRD["Kuadrant, AuthPolicy<br/>RateLimitPolicy, DNSPolicy<br/>TLSPolicy, KuadrantControlPlane"]
         A_CRD["Authorino, AuthConfig"]
         L_CRD["Limitador"]
         D_CRD["DNSRecord<br/>DNSHealthCheckProbe"]
         M_CRD["MCPGatewayExtension<br/>MCPServerRegistration<br/>MCPVirtualServer"]
     end
 
+    KCP["KuadrantControlPlane CR<br/>(auto-created singleton)"]
+
     subgraph installed-by["Installed by"]
         INSTALLER["Helm or OLM"] -.-> K_CRD
         INSTALLER -.-> KOP
-        KOP -->|"renders charts<br/>at startup"| AO
-        KOP -->|"renders charts<br/>at startup"| LO
-        KOP -->|"renders charts<br/>at startup"| DO
-        KOP -->|"renders charts<br/>at startup"| MG
-        KOP -->|"applies CRDs<br/>at startup"| A_CRD
-        KOP -->|"applies CRDs<br/>at startup"| L_CRD
-        KOP -->|"applies CRDs<br/>at startup"| D_CRD
-        KOP -->|"applies CRDs<br/>at startup"| M_CRD
     end
+
+    subgraph bootstrap["Pre-manager CRD bootstrap"]
+        KOP -->|"applies CRDs<br/>before manager starts"| A_CRD
+        KOP -->|"applies CRDs<br/>before manager starts"| L_CRD
+        KOP -->|"applies CRDs<br/>before manager starts"| D_CRD
+        KOP -->|"applies CRDs<br/>before manager starts"| M_CRD
+    end
+
+    KOP -->|"auto-creates"| KCP
+    KCP -->|"triggers<br/>reconciliation"| AO
+    KCP -->|"triggers<br/>reconciliation"| LO
+    KCP -->|"triggers<br/>reconciliation"| DO
+    KCP -->|"triggers<br/>reconciliation"| MG
 
     KOP -.->|"waiting for<br/>Kuadrant CR"| IDLE["No Kuadrant-managed data plane workloads yet<br/>Component controllers already running"]
 ```
 
-All component controllers, CRDs, and ClusterRoles are deployed at operator startup before the controller manager begins watching resources. No Kuadrant CR is needed for the control plane to be running. MCPGatewayExtension is an exception — it is created directly by the user and reconciled by the mcp-gateway controller independently of the Kuadrant CR.
+The startup sequence has two phases:
+1. **Pre-manager**: CRDs are applied and established before the controller manager starts (required for PolicyMachineryController boot detection)
+2. **Post-manager**: the KuadrantControlPlane controller reconciles the auto-created CR, deploying all component controllers, RBAC, and services
+
+No Kuadrant CR is needed for the control plane to be running. MCPGatewayExtension is an exception, it is created directly by the user and reconciled by the mcp-gateway controller independently of the Kuadrant CR.
 
 ## Runtime: Reconciliation Chain
 
@@ -145,7 +156,7 @@ graph LR
     end
 
     subgraph roles["ClusterRoles"]
-        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ escalate/bind on component roles<br/>+ CRD create"]
+        KR["kuadrant-operator-manager<br/>infrastructure perms<br/>+ escalate/bind on component roles<br/>+ CRD create/list/watch"]
         AR["authorino-operator-manager<br/>authorino-manager-role<br/>authorino-manager-k8s-auth-role"]
         LR_["limitador-operator-manager-role"]
         DR["dns-operator-manager-role<br/>dns-operator-remote-cluster-role"]
@@ -175,7 +186,7 @@ graph LR
     MSA --> MR
 ```
 
-The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All component ClusterRoles, SAs, and CRBs are created by the kuadrant-operator at startup using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
+The installer (Helm or OLM) only installs the kuadrant-operator's own SA, ClusterRole, and CRB. All component ClusterRoles, SAs, and CRBs are created by the kuadrant-operator via the KuadrantControlPlane controller using `escalate` (to create ClusterRoles with permissions it does not hold) and `bind` (to create CRBs referencing those ClusterRoles).
 
 ## Resource Ownership
 
@@ -186,12 +197,14 @@ graph TB
     USER -->|"creates"| MGCR["MCPGatewayExtension CR"]
 
     subgraph installer["Installed by Helm or OLM"]
-        KOP_CRDs["kuadrant-operator CRDs"]
+        KOP_CRDs["kuadrant-operator CRDs<br/>(incl. KuadrantControlPlane)"]
         KOP_DEP["kuadrant-operator Deployment"]
         KOP_RBAC["kuadrant-operator SA, ClusterRole, CRB"]
     end
 
-    subgraph startup["Deployed by kuadrant-operator at startup"]
+    KCP["KuadrantControlPlane CR<br/>(auto-created)"]
+
+    subgraph controlplane["Deployed by KuadrantControlPlane controller"]
         COMP_CRDs["Component CRDs"]
         COMP_CR["Component ClusterRoles"]
         AUTH_OP["authorino-operator Deployment + SA + CRB"]
@@ -214,6 +227,6 @@ graph TB
 ```
 
 Three layers of resource ownership:
-1. **Installer** (Helm/OLM): kuadrant-operator's own resources only
-2. **kuadrant-operator at startup**: component CRDs, ClusterRoles, controllers (not tied to any CR)
+1. **Installer** (Helm/OLM): kuadrant-operator's own resources only (including KuadrantControlPlane CRD)
+2. **KuadrantControlPlane controller**: component CRDs, ClusterRoles, controllers, driven by the auto-created KuadrantControlPlane CR, independent of Kuadrant CR. All resources labelled `app.kubernetes.io/managed-by: kuadrant-operator`
 3. **kuadrant-operator via Kuadrant CR**: wrapper CRs that trigger data plane workloads


### PR DESCRIPTION
## Summary

Updates RFC 0019 (Kuadrant Operator Consolidation) to reflect the implementation of KuadrantControlPlane CRD, chart sync tooling, and OLM migration cleanup as implemented in Kuadrant/kuadrant-operator#2156.

### KuadrantControlPlane CRD
- New cluster-scoped singleton CRD for control plane lifecycle management
- CEL validation enforcing singleton (name must be "default"), self-healing on deletion
- Status with per-component health (Deployment readiness, CRD establishment, image reference)
- Standard controller-runtime reconciler, separate from PolicyMachineryController (data plane)
- Two-phase startup: pre-manager CRD bootstrap, then controller-driven deployment

### Resource labelling
- All rendered resources stamped with `app.kubernetes.io/managed-by: kuadrant-operator`
- OLM migration strips stale OLM labels and ownerReferences via dynamic label-selector discovery

### Chart sync tooling
- `sync.yaml` config with commit SHA pinning, `repository_dispatch` automation
- Go CLI tool for chart synchronisation

### RBAC
- Added `list`/`watch` to unscoped CRD rule (required for controller-runtime informer cache)

### Architecture diagrams
- Updated for KuadrantControlPlane-driven deployment model
- Shows two-phase startup, resource ownership layers, managed-by labelling

### Resolved questions
- Control plane status CR moved from unresolved to implemented

Relates to Kuadrant/kuadrant-operator#2154
Relates to Kuadrant/kuadrant-operator#2155
Relates to Kuadrant/kuadrant-operator#2156